### PR TITLE
Add recordIPAddress option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ For more information, please visit our [docs](http://support.kadira.io/knowledge
 The Monti APM agent can be configured by
 
 - environment variables, prefixed with either `MONTI_` or `KADIRA_`
-- settings.json in the `monti` or `kadira` object
+- settings.json in the `monti` or `kadira` object. Options other than `appId` and `appSecret` should be in `monti.options` or `kadira.options`.
 - code with `Monti.connect('app id', 'app secret', options)`
 
 You should use the same method that you used to give the agent the app id and secret.

--- a/README.md
+++ b/README.md
@@ -55,3 +55,25 @@ export MONTI_APP_SECRET=<appSecret>
 
 Monti APM comes with built in error tracking solution for Meteor apps. It has been enabled by default.
 For more information, please visit our [docs](http://support.kadira.io/knowledgebase/topics/62637-error-tracking) on [error tracking](http://support.kadira.io/knowledgebase/topics/62637-error-tracking).
+
+### Options
+
+The Monti APM agent can be configured by
+
+- environment variables, prefixed with either `MONTI_` or `KADIRA_`
+- settings.json in the `monti` or `kadira` object
+- code with `Monti.connect('app id', 'app secret', options)`
+
+You should use the same method that you used to give the agent the app id and secret.
+
+#### List of Options
+
+| name | env variable | default | description |
+|------|--------------|---------|-------------|
+| appId | APP_ID | none | |
+| appSecret | APP_SECRET | none | |
+| enableErrorTracking | OPTIONS_ENABLE_ERROR_TRACKING | true | enable sending errors to Monti APM |
+| endpoint | OPTIONS_ENDPOINT | https://engine.montiapm.com | Monti / Kadira engine url |
+| hostname | OPTIONS_HOSTNAME | Server's hostname | What the instance is named in Monti APM |
+| uploadSourceMaps | UPLOAD_SOURCE_MAPS | true | Enables sending source maps to Monti APM to improve error stack traces |
+| recordIPAddress | RECORD_IP_ADDRESS | 'full' | Set to 'full' to record IP Address, 'anonymized' to anonymize last octet of address, or 'none' to not record an IP Address for client errors |

--- a/lib/client/models/errors.js
+++ b/lib/client/models/errors.js
@@ -68,6 +68,7 @@ ErrorModel.prototype._buildPayload = function(errors) {
 
   return {
     host: Kadira.options.hostname,
+    recordIPAddress: Kadira.options.recordIPAddress,
     errors: errors,
     arch: arch,
     archVersion: getClientArchVersion(arch)

--- a/lib/environment_variables.js
+++ b/lib/environment_variables.js
@@ -105,7 +105,11 @@ Kadira._parseEnv._options = {
   },
   // enable uploading sourcemaps
   MONTI_UPLOAD_SOURCE_MAPS: {
-    name: 'uploadSourcemaps',
+    name: 'uploadSourceMaps',
     parser: Kadira._parseEnv.parseBool
+  },
+  MONTI_RECORD_IP_ADDRESS: {
+    name: 'recordIPAddress',
+    parser: Kadira._parseEnv.parseString,
   }
 };

--- a/lib/kadira.js
+++ b/lib/kadira.js
@@ -31,6 +31,7 @@ Kadira.connect = function(appId, appSecret, options) {
   options.isHostNameSet = !!options.hostname;
   options.hostname = options.hostname || hostname;
   options.proxy = options.proxy || null;
+  options.recordIPAddress = options.recordIPAddress || 'full';
 
   if(options.documentSizeCacheSize) {
     Kadira.docSzCache = new DocSzCache(options.documentSizeCacheSize, 10);
@@ -71,6 +72,7 @@ Kadira.connect = function(appId, appSecret, options) {
     appId: appId,
     endpoint: options.endpoint,
     clientEngineSyncDelay: options.clientEngineSyncDelay,
+    recordIPAddress: options.recordIPAddress,
   };
 
   if(options.enableErrorTracking) {

--- a/tests/client/models/errors.js
+++ b/tests/client/models/errors.js
@@ -241,6 +241,7 @@ function buildPayload(errors) {
     errors: errors,
     host: undefined,
     arch: arch,
-    archVersion: archVersion
+    archVersion: archVersion,
+    recordIPAddress: 'full'
   }
 }


### PR DESCRIPTION
This option can be used to have Monti APM anonymize IP addresses or not record them at all.