### PR TITLE
Fix/trace limits

### DIFF
--- a/lib/hijack/wrap_session.js
+++ b/lib/hijack/wrap_session.js
@@ -1,3 +1,5 @@
+const MAX_PARAMS_LENGTH = 4000
+
 wrapSession = function(sessionProto) {
   var originalProcessMessage = sessionProto.processMessage;
   sessionProto.processMessage = function(msg) {
@@ -12,7 +14,15 @@ wrapSession = function(sessionProto) {
         Kadira.waitTimeBuilder.register(this, msg.id);
 
         //use JSON stringify to save the CPU
-        var startData = { userId: this.userId, params: JSON.stringify(msg.params) };
+        let stringifiedParams = JSON.stringify(msg.params);
+
+        // The params could be several mb or larger.
+        // Truncate if it is large
+        if (stringifiedParams.length > MAX_PARAMS_LENGTH) {
+          stringifiedParams = `Monti APM: params are too big. First ${MAX_PARAMS_LENGTH} characters: ${stringifiedParams.slice(0, MAX_PARAMS_LENGTH)}`;
+        }
+
+        var startData = { userId: this.userId, params: stringifiedParams };
         Kadira.tracer.event(kadiraInfo.trace, 'start', startData);
         var waitEventId = Kadira.tracer.event(kadiraInfo.trace, 'wait', {}, kadiraInfo);
         msg._waitEventId = waitEventId;

--- a/lib/tracer/tracer.js
+++ b/lib/tracer/tracer.js
@@ -1,6 +1,7 @@
 var eventLogger = Npm.require('debug')('kadira:tracer');
 var REPITITIVE_EVENTS = {'db': true, 'http': true, 'email': true, 'wait': true, 'async': true, 'custom': true};
 var TRACE_TYPES = ['sub', 'method'];
+var MAX_TRACE_EVENTS = 1500;
 
 Tracer = function Tracer() {
   this._filters = [];
@@ -265,6 +266,11 @@ Tracer.prototype.buildTrace = function (traceInfo) {
   var lastEventData = [lastEvent.type, 0];
   if(lastEvent.data) lastEventData.push(lastEvent.data);
   processedEvents.push(lastEventData);
+
+  if (processedEvents.length > MAX_TRACE_EVENTS) {
+    const removeCount = processedEvents.length - MAX_TRACE_EVENTS
+    processedEvents.splice(MAX_TRACE_EVENTS, removeCount);
+  }
 
   metrics.compute = metrics.total - totalNonCompute;
   traceInfo.metrics = metrics;

--- a/tests/tracer/tracer.js
+++ b/tests/tracer/tracer.js
@@ -293,6 +293,30 @@ Tinytest.add(
 );
 
 Tinytest.add(
+  'Tracer - Build Trace - truncate events',
+  function (test) {
+    var now = (new Date).getTime();
+    var traceInfo = {
+      events: [
+        {...eventDefaults, type: 'start', at: now},
+        {...eventDefaults, type: 'wait', at: now, endAt: now},
+      ]
+    };
+    
+    for (let i = 0; i < 10000; i++) {
+      traceInfo.events.push({ ...eventDefaults, type: 'db', at: now, endAt: now + 500 });
+      now += 500
+    }
+
+    traceInfo.events.push({...eventDefaults, type: 'complete', at: now + 2500});
+    Kadira.tracer.buildTrace(traceInfo);
+
+    test.equal(traceInfo.metrics.db, 5000000);
+    test.equal(traceInfo.events.length, 1500);
+  }
+)
+
+Tinytest.add(
   'Tracer - Filters - filter start',
   function(test) {
     var tracer = new Tracer();


### PR DESCRIPTION
Some traces are very large which causes the Kadira engine to reject the whole payload. For some apps this causes them to stop showing data.