### PR TITLE
HTTP Monitoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ env:
     - METEOR_RELEASE=1.5.4.1
     - METEOR_RELEASE=1.6.0.1
     - METEOR_RELEASE=1.7.0.5
-    - METEOR_RELASE=1.8.0.2
+    - METEOR_RELEASE=1.8.0.2
     - METEOR_RELEASE=1.8.1
-    - METEOR_RELEASE=1.9-alpha.7
+    - METEOR_RELEASE=1.8.2
+    - METEOR_RELEASE=1.9-rc.1
 script: mtest --package ./ --once --release $METEOR_RELEASE

--- a/lib/hijack/instrument.js
+++ b/lib/hijack/instrument.js
@@ -1,3 +1,5 @@
+import { wrapWebApp } from "./wrap_webapp";
+
 var logger = Npm.require('debug')('kadira:hijack:instrument');
 
 var instrumented = false;
@@ -8,7 +10,9 @@ Kadira._startInstrumenting = function(callback) {
   }
 
   instrumented = true;
-  wrapStringifyDDP()
+  wrapStringifyDDP();
+  wrapWebApp();
+  
   MeteorX.onReady(function() {
     //instrumenting session
     wrapServer(MeteorX.Server.prototype);

--- a/lib/hijack/wrap_webapp.js
+++ b/lib/hijack/wrap_webapp.js
@@ -1,0 +1,116 @@
+import { WebAppInternals, WebApp } from 'meteor/webapp';
+
+export function wrapWebApp() {
+  // TODO: add this handler directly to the connect instance's stack
+  // so we can make sure it is the first middleware
+  WebApp.rawConnectHandlers.use((req, res, next) => {
+    const trace = Kadira.tracer.start(`${req.method}-${req.url}`, 'http');
+    Kadira.tracer.event(trace, 'start');
+    req.__kadiraInfo = { trace };
+
+    res.on('finish', () => {
+      if (req.__kadiraInfo.asyncEvent) {
+        Kadira.tracer.eventEnd(trace, req.__kadiraInfo.asyncEvent);
+      }
+
+      Kadira.tracer.endLastEvent(trace);
+
+      // TODO: record response status code and body size
+      Kadira.tracer.event(trace, 'complete');
+      let built = Kadira.tracer.buildTrace(trace);
+      Kadira.models.http.processRequest(built, req, res);
+    });
+
+    next();
+  });
+
+
+  function wrapHandler(handler) {
+    // connect identifies error handles by them accepting
+    // four arguments
+    let errorHandler = handler.length === 4;
+
+    async function wrapper(req, res, next) {
+      let error;
+      if (errorHandler) {
+        error = req;
+        req = res;
+        res = next;
+        next = arguments[3]
+      }
+
+      const kadiraInfo = req.__kadiraInfo;
+      Kadira._setInfo(kadiraInfo);
+
+      let nextCalled = false;
+      // TODO: track errors passed to next or thrown
+      function wrappedNext(...args) {
+        if (kadiraInfo && kadiraInfo.asyncEvent) {
+          Kadira.tracer.eventEnd(req.__kadiraInfo.trace, req.__kadiraInfo.asyncEvent);
+          req.__kadiraInfo.asyncEvent = null;
+        }
+
+        nextCalled = true;
+        next(...args)
+      }
+
+      let result
+
+      if (errorHandler) {
+        result = await handler(error, req, res, wrappedNext);
+      } else {
+        result = await handler(req, res, wrappedNext);
+      }
+
+      // res.finished is depreciated in Node 13, but it is the only option
+      // for Node 12.9 and older.
+      if (kadiraInfo && !res.finished && !nextCalled) {
+        // req is not done, and next has not been called
+        // create an async event that will end when either of those happens
+        kadiraInfo.asyncEvent = Kadira.tracer.event(kadiraInfo.trace, 'async');
+      }
+
+      return result;
+    }
+
+    if (errorHandler) {
+      return function (error, req, res, next) {
+        return wrapper(error, req, res, next);
+      }
+    } else {
+      return function (req, res, next) {
+        return wrapper(req, res, next);
+      }
+    }
+  }
+
+  function wrapConnect(app, wrapStack) {
+    let oldUse = app.use;
+    if (wrapStack) {
+      // TODO: run in fiber so the kadira info on fiber can be copied
+      // for the actual handler, since Meteor wraps handlers also to be in a fiber
+      // app.stack.forEach(entry => {
+      //   // TODO: use correct number of arguments 
+      //   entry.handle = function (req, res, next) {
+      //   }
+      // });
+    }
+    app.use = function (...args) {
+      args[args.length - 1] = wrapHandler(args[args.length - 1])
+      oldUse.apply(app, args);
+    }
+  }
+
+  // TODO: check how far back Meteor had these, and if it changed over time
+  wrapConnect(WebApp.rawConnectHandlers, false);
+  wrapConnect(WebAppInternals.meteorInternalHandlers, false);
+  wrapConnect(WebApp.connectHandlers, false);
+  wrapConnect(WebApp.connectApp, false);
+
+  let oldStaticFilesMiddleware = WebAppInternals.staticFilesMiddleware;
+  // TODO: check how far back Meteor's static files middleware works like this
+  const staticHandler = wrapHandler(oldStaticFilesMiddleware.bind(WebAppInternals, WebAppInternals.staticFilesByArch));
+  WebAppInternals.staticFilesMiddleware = function (_staticFiles, req, res, next) {
+    return staticHandler(req, res, next);
+  };
+}

--- a/lib/kadira.js
+++ b/lib/kadira.js
@@ -1,3 +1,5 @@
+import HttpModel from "./models/http";
+
 var hostname = Npm.require('os').hostname();
 var logger = Npm.require('debug')('kadira:apm');
 var Fibers = Npm.require('fibers');
@@ -17,6 +19,7 @@ Kadira.errors.addFilter = Kadira.errors.push.bind(Kadira.errors);
 Kadira.models.methods = new MethodsModel();
 Kadira.models.pubsub = new PubsubModel();
 Kadira.models.system = new SystemModel();
+Kadira.models.http = new HttpModel();
 Kadira.docSzCache = new DocSzCache(100000, 10);
 
 
@@ -135,6 +138,8 @@ Kadira._buildPayload = function () {
   _.extend(payload, Kadira.models.methods.buildPayload(buildDetailedInfo));
   _.extend(payload, Kadira.models.pubsub.buildPayload(buildDetailedInfo));
   _.extend(payload, Kadira.models.system.buildPayload());
+  _.extend(payload, Kadira.models.http.buildPayload());
+
   if(Kadira.options.enableErrorTracking) {
     _.extend(payload, Kadira.models.error.buildPayload());
   }

--- a/lib/models/http.js
+++ b/lib/models/http.js
@@ -1,0 +1,116 @@
+const METHOD_METRICS_FIELDS = ['db', 'http', 'email', 'async', 'compute', 'total'];
+
+
+const HttpModel = function () {
+  this.metricsByMinute = Object.create(null);
+  this.tracerStore = new TracerStore({
+    interval: 1000 * 10,
+    maxTotalPoints: 30,
+    archiveEvery: 10
+  });
+
+  this.tracerStore.start();
+}
+
+_.extend(HttpModel.prototype, KadiraModel.prototype);
+
+HttpModel.prototype.processRequest = function (trace, req, res) {
+  const dateId = this._getDateId(trace.at);
+  this._appendMetrics(dateId, trace, res);
+  this.tracerStore.addTrace(trace);
+}
+
+HttpModel.prototype._getMetrics = function (timestamp, routeId) {
+  const dateId = this._getDateId(timestamp);
+
+  if (!this.metricsByMinute[dateId]) {
+    this.metricsByMinute[dateId] = {
+      routes: Object.create(null)
+    };
+  }
+
+  const routes = this.metricsByMinute[dateId].routes;
+
+  if (!routes[routeId]) {
+    routes[routeId] = {
+      count: 0,
+      errors: 0,
+      statusCodes: Object.create(null)
+    };
+
+    METHOD_METRICS_FIELDS.forEach(function (field) {
+      routes[routeId][field] = 0;
+    });
+  }
+
+  return this.metricsByMinute[dateId].routes[routeId];
+}
+
+HttpModel.prototype._appendMetrics = function (dateId, trace, res) {
+  var requestMetrics = this._getMetrics(dateId, trace.name);
+
+  if (!this.metricsByMinute[dateId].startTime) {
+    this.metricsByMinute[dateId].startTime = trace.at;
+  }
+
+  // merge
+  METHOD_METRICS_FIELDS.forEach(field => {
+    var value = trace.metrics[field];
+    if (value > 0) {
+      requestMetrics[field] += value;
+    }
+  });
+
+  const statusCode = res.statusCode;
+  let statusMetric;
+
+  if (statusCode < 200) {
+    statusMetric = '1xx';
+  } else if (statusCode < 300) {
+    statusMetric = '2xx';
+  } else if (statusCode < 400) {
+    statusMetric = '3xx';
+  } else if (statusCode < 500) {
+    statusMetric = '4xx';
+  } else if (statusCode < 600) {
+    statusMetric = '5xx';
+  }
+
+  requestMetrics.statusCodes[statusMetric] = requestMetrics.statusCodes[statusMetric] || 0;
+  requestMetrics.statusCodes[statusMetric] += 1;
+
+  requestMetrics.count += 1;
+  this.metricsByMinute[dateId].endTime = trace.metrics.at;
+}
+
+HttpModel.prototype.buildPayload = function() {
+  var payload = {
+    httpMetrics: [],
+    httpRequests: []
+  };
+
+  var metricsByMinute = this.metricsByMinute;
+  this.metricsByMinute = Object.create(null);
+
+  for(var key in metricsByMinute) {
+    var metrics = metricsByMinute[key];
+    // convert startTime into the actual serverTime
+    var startTime = metrics.startTime;
+    metrics.startTime = Kadira.syncedDate.syncTime(startTime);
+
+    for(var requestName in metrics.requests) {
+      METHOD_METRICS_FIELDS.forEach(function (field) {
+        metrics.requests[requestName][field] /= metrics.requests[requestName].count;
+      });
+    }
+
+    payload.httpMetrics.push(metricsByMinute[key]);
+  }
+
+  payload.httpRequests = this.tracerStore.collectTraces();
+
+  
+  return payload;
+}
+
+export default HttpModel;

--- a/lib/tracer/tracer.js
+++ b/lib/tracer/tracer.js
@@ -252,7 +252,7 @@ Tracer.prototype.buildTrace = function (traceInfo) {
     }
   }
 
-  computeTime = lastEvent.at - traceInfo.events[traceInfo.events.length - 1].endAt;
+  computeTime = lastEvent.at - traceInfo.events[traceInfo.events.length - 2].endAt;
   if(computeTime > 0) processedEvents.push(['compute', computeTime]);
 
   var lastEventData = [lastEvent.type, 0];

--- a/lib/tracer/tracer.js
+++ b/lib/tracer/tracer.js
@@ -1,6 +1,6 @@
 var eventLogger = Npm.require('debug')('kadira:tracer');
-var REPITITIVE_EVENTS = {'db': true, 'http': true, 'email': true, 'wait': true, 'async': true, 'custom': true};
-var TRACE_TYPES = ['sub', 'method'];
+var REPETITIVE_EVENTS = {'db': true, 'http': true, 'email': true, 'wait': true, 'async': true, 'custom': true};
+var TRACE_TYPES = ['sub', 'method', 'http'];
 var MAX_TRACE_EVENTS = 1500;
 
 Tracer = function Tracer() {
@@ -75,8 +75,8 @@ Tracer.prototype.event = function (traceInfo, type, data, metaData) {
     nested: [],
   };
 
-  // special handling for events that are not repititive
-  if (!REPITITIVE_EVENTS[type]) {
+  // special handling for events that are not repetitive
+  if (!REPETITIVE_EVENTS[type]) {
     event.endAt = event.at;
   }
 


### PR DESCRIPTION
This adds monitoring for incoming http requests. The basics work, but there is a lot of polishing needed and additional features to implement.

What is implemented:
- Throughput and response time metrics
- The number of responses for each status code. We only store the 100's place (300 and 304 are both stored as 3xx)
- Creates traces. Currently there is a lot of compute and async time, but as we instrument things that are commonly used in middleware (such as fs) and prevent any unnecessary events, this will get more useful.
- There is a new `Impact` sort option in the UI. Improving the response time for routes higher on the list will have the largest benefit.

This requires Meteor 1.6.1 or newer since that is the first version that runs all middleware in a fiber. Before this PR is merged it will automatically detect that and only monitor on supported versions.

Time spent by middleware that was added before the agent instrumented WebApp is currently not tracked (except for Meteor's static middleware). It should be possible to fix this.

### Try HTTP Monitoring
1) Update the agent to the 2.39 beta: `meteor add montiapm:agent@2.39.0-beta.1`
2) Run your app and open it in a browser. A minute after the first http request, you should see a new `HTTP` dashboard show up on Monti APM

![image](https://user-images.githubusercontent.com/8175744/71609316-008df180-2b4d-11ea-8d19-62c82b5abda3.png)

