### PR TITLE
Passthrough meteor error details.

### DIFF
--- a/lib/hijack/wrap_session.js
+++ b/lib/hijack/wrap_session.js
@@ -112,7 +112,7 @@ wrapSession = function(sessionProto) {
       var kadiraInfo = Kadira._getInfo();
       if(kadiraInfo) {
         if(msg.error) {
-          var error = _.pick(msg.error, ['message', 'stack']);
+          var error = _.pick(msg.error, ['message', 'stack', 'details']);
 
           // pick the error from the wrapped method handler
           if(kadiraInfo && kadiraInfo.currentError) {


### PR DESCRIPTION
According to lib/models/errors.js line 45-48, it does expect the error details be there. But here, we did not pick it up. So this PR will save you time from figure out what's really happened on a certain mentor error.