### PR TITLE
Weaken optional packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         meteorRelease:
-          - '--release 1.4.4.5'
+          - '--release 1.4.4.6'
           - '--release 1.5.4.1'
           - '--release 1.6.0.1'
           - '--release 1.7.0.5'

--- a/lib/hijack/email.js
+++ b/lib/hijack/email.js
@@ -1,21 +1,25 @@
-var originalSend = Email.send;
+if (Package['email']) {
+  const Email = Package['email'].Email;
+
+  var originalSend = Email.send;
 
 Email.send = function(options) {
-  var kadiraInfo = Kadira._getInfo();
+    var kadiraInfo = Kadira._getInfo();
   if(kadiraInfo) {
-    var data = _.pick(options, 'from', 'to', 'cc', 'bcc', 'replyTo');
-    var eventId = Kadira.tracer.event(kadiraInfo.trace, 'email', data);
-  }
-  try {
-    var ret = originalSend.call(this, options);
-    if(eventId) {
-      Kadira.tracer.eventEnd(kadiraInfo.trace, eventId);
+      var data = _.pick(options, 'from', 'to', 'cc', 'bcc', 'replyTo');
+      var eventId = Kadira.tracer.event(kadiraInfo.trace, 'email', data);
     }
-    return ret;
+    try {
+      var ret = originalSend.call(this, options);
+    if(eventId) {
+        Kadira.tracer.eventEnd(kadiraInfo.trace, eventId);
+      }
+      return ret;
   } catch(ex) {
     if(eventId) {
       Kadira.tracer.eventEnd(kadiraInfo.trace, eventId, {err: ex.message});
+      }
+      throw ex;
     }
-    throw ex;
-  }
-};
+  };
+}

--- a/lib/hijack/http.js
+++ b/lib/hijack/http.js
@@ -1,25 +1,29 @@
-var originalCall = HTTP.call;
+if (Package['http']) {
+  const HTTP = Package['http'].HTTP;
+
+  var originalCall = HTTP.call;
 
 HTTP.call = function(method, url) {
-  var kadiraInfo = Kadira._getInfo();
+    var kadiraInfo = Kadira._getInfo();
   if(kadiraInfo) {
     var eventId = Kadira.tracer.event(kadiraInfo.trace, 'http', {method: method, url: url});
-  }
+    }
 
-  try {
-    var response = originalCall.apply(this, arguments);
+    try {
+      var response = originalCall.apply(this, arguments);
 
-    //if the user supplied an asynCallback, we don't have a response object and it handled asynchronously
-    //we need to track it down to prevent issues like: #3
+      //if the user supplied an asynCallback, we don't have a response object and it handled asynchronously
+      //we need to track it down to prevent issues like: #3
     var endOptions = HaveAsyncCallback(arguments)? {async: true}: {statusCode: response.statusCode};
     if(eventId) {
-      Kadira.tracer.eventEnd(kadiraInfo.trace, eventId, endOptions);
-    }
-    return response;
+        Kadira.tracer.eventEnd(kadiraInfo.trace, eventId, endOptions);
+      }
+      return response;
   } catch(ex) {
     if(eventId) {
       Kadira.tracer.eventEnd(kadiraInfo.trace, eventId, {err: ex.message});
+      }
+      throw ex;
     }
-    throw ex;
-  }
-};
+  };
+}

--- a/lib/hijack/http.js
+++ b/lib/hijack/http.js
@@ -3,10 +3,10 @@ if (Package['http']) {
 
   var originalCall = HTTP.call;
 
-HTTP.call = function(method, url) {
+  HTTP.call = function (method, url) {
     var kadiraInfo = Kadira._getInfo();
-  if(kadiraInfo) {
-    var eventId = Kadira.tracer.event(kadiraInfo.trace, 'http', {method: method, url: url});
+    if (kadiraInfo) {
+      var eventId = Kadira.tracer.event(kadiraInfo.trace, 'http', { method: method, url: url });
     }
 
     try {
@@ -14,14 +14,14 @@ HTTP.call = function(method, url) {
 
       //if the user supplied an asynCallback, we don't have a response object and it handled asynchronously
       //we need to track it down to prevent issues like: #3
-    var endOptions = HaveAsyncCallback(arguments)? {async: true}: {statusCode: response.statusCode};
-    if(eventId) {
+      var endOptions = HaveAsyncCallback(arguments) ? { async: true } : { statusCode: response.statusCode };
+      if (eventId) {
         Kadira.tracer.eventEnd(kadiraInfo.trace, eventId, endOptions);
       }
       return response;
-  } catch(ex) {
-    if(eventId) {
-      Kadira.tracer.eventEnd(kadiraInfo.trace, eventId, {err: ex.message});
+    } catch (ex) {
+      if (eventId) {
+        Kadira.tracer.eventEnd(kadiraInfo.trace, eventId, { err: ex.message });
       }
       throw ex;
     }

--- a/lib/ntp.js
+++ b/lib/ntp.js
@@ -135,6 +135,7 @@ function getLogger() {
     return Npm.require('debug')("kadira:ntp");
   } else {
     return function(message) {
+      try {
       var canLogKadira =
         global && global.localStorage.getItem('LOG_KADIRA') !== null
         && typeof console !== 'undefined';
@@ -146,6 +147,7 @@ function getLogger() {
         }
         console.log.apply(console, arguments);
       }
+    } catch(e) {} //older browsers can sometimes throw because of getItem
     }
   }
 }

--- a/lib/ntp.js
+++ b/lib/ntp.js
@@ -115,9 +115,9 @@ Ntp.prototype.getServerTime = function(callback) {
       var serverTime = parseInt(content);
       callback(null, serverTime);
     })
-    .catch(err => {
-      callback(err);
-    });
+      .catch(err => {
+        callback(err);
+      });
   } else {
     httpRequest('GET', self.endpoint + `?noCache=${new Date().getTime()}-${Math.random()}`, function(err, res) {
       if (err) {
@@ -136,7 +136,7 @@ function getLogger() {
   } else {
     return function(message) {
       var canLogKadira =
-        Meteor._localStorage.getItem('LOG_KADIRA') !== null
+        global?.localStorage?.getItem('LOG_KADIRA') !== null
         && typeof console !== 'undefined';
 
       if(canLogKadira) {

--- a/lib/ntp.js
+++ b/lib/ntp.js
@@ -136,8 +136,7 @@ function getLogger() {
   } else {
     return function(message) {
       try {
-        var canLogKadira = global.localStorage.getItem('LOG_KADIRA') !== null
-          && typeof console !== 'undefined';
+        var canLogKadira = global.localStorage.getItem('LOG_KADIRA') !== null && typeof console !== 'undefined';
       } catch (e) { } //older browsers can sometimes throw because of getItem
       if (canLogKadira) {
         if (message) {

--- a/lib/ntp.js
+++ b/lib/ntp.js
@@ -136,7 +136,7 @@ function getLogger() {
   } else {
     return function(message) {
       var canLogKadira =
-        global?.localStorage?.getItem('LOG_KADIRA') !== null
+        global && global.localStorage.getItem('LOG_KADIRA') !== null
         && typeof console !== 'undefined';
 
       if(canLogKadira) {

--- a/lib/ntp.js
+++ b/lib/ntp.js
@@ -136,18 +136,16 @@ function getLogger() {
   } else {
     return function(message) {
       try {
-      var canLogKadira =
-        global && global.localStorage.getItem('LOG_KADIRA') !== null
-        && typeof console !== 'undefined';
-
-      if(canLogKadira) {
-        if(message) {
+        var canLogKadira = global.localStorage.getItem('LOG_KADIRA') !== null
+          && typeof console !== 'undefined';
+      } catch (e) { } //older browsers can sometimes throw because of getItem
+      if (canLogKadira) {
+        if (message) {
           message = "kadira:ntp " + message;
           arguments[0] = message;
         }
         console.log.apply(console, arguments);
       }
-    } catch(e) {} //older browsers can sometimes throw because of getItem
     }
   }
 }

--- a/package.js
+++ b/package.js
@@ -101,11 +101,11 @@ function configurePackage(api) {
   api.use('zodern:meteor-package-versions@0.2.0');
 
   api.use([
-    'minimongo', 'ejson', 'ddp-common',
+    'minimongo', 'mongo', 'ddp', 'ejson', 'ddp-common',
     'underscore', 'random', 'webapp', 'ecmascript'
   ], ['server']);
 
-  api.use(['http@1.0.0||2.0.0', 'email@1.0.0||2.0.0', 'mongo', 'ddp'], 'server', { weak: true });
+  api.use(['http@1.0.0||2.0.0', 'email@1.0.0||2.0.0'], 'server', { weak: true });
   api.use(['random', 'ecmascript', 'tracker'], ['client']);
 
   // common before

--- a/package.js
+++ b/package.js
@@ -24,12 +24,12 @@ var npmModules = {
 Npm.depends(npmModules);
 
 Package.onUse(function (api) {
-  configurePackage(api);
+  configurePackage({ api, isTesting: false });
   api.export(['Kadira', 'Monti']);
 });
 
 Package.onTest(function (api) {
-  configurePackage(api, 'test');
+  configurePackage({ api, isTesting: true });
   api.use([
     'tinytest',
     'test-helpers',
@@ -93,7 +93,7 @@ Package.onTest(function (api) {
   ], ['client', 'server']);
 });
 
-function configurePackage(api, mode) {
+function configurePackage({ api, isTesting }) {
   api.versionsFrom('METEOR@1.4');
   api.use('montiapm:meteorx@2.2.0', ['server']);
   api.use('meteorhacks:zones@1.2.1', { weak: true });
@@ -104,7 +104,7 @@ function configurePackage(api, mode) {
     'minimongo', 'mongo', 'ddp', 'ejson', 'ddp-common',
     'underscore', 'random', 'webapp', 'ecmascript'
   ], ['server']);
-  api.use(['http@1.0.0||2.0.0', 'email@1.0.0||2.0.0'], 'server', { weak: mode !== 'test' });
+  api.use(['http@1.0.0||2.0.0', 'email@1.0.0||2.0.0'], 'server', { weak: !isTesting });
   api.use(['random', 'ecmascript', 'tracker'], ['client']);
 
   // common before

--- a/package.js
+++ b/package.js
@@ -29,7 +29,7 @@ Package.onUse(function(api) {
 });
 
 Package.onTest(function(api) {
-  configurePackage(api);
+  configurePackage(api, 'test');
   api.use([
     'tinytest',
     'test-helpers',
@@ -93,7 +93,7 @@ Package.onTest(function(api) {
   ], ['client', 'server']);
 });
 
-function configurePackage(api) {
+function configurePackage(api, mode) {
   api.versionsFrom('METEOR@1.4');
   api.use('montiapm:meteorx@2.2.0', ['server']);
   api.use('meteorhacks:zones@1.2.1', {weak: true});
@@ -104,8 +104,11 @@ function configurePackage(api) {
     'minimongo', 'mongo', 'ddp', 'ejson', 'ddp-common',
     'underscore', 'random', 'webapp', 'ecmascript'
   ], ['server']);
-
-  api.use(['http@1.0.0||2.0.0', 'email@1.0.0||2.0.0'], 'server', { weak: true });
+  if (mode !== 'test') {
+    api.use(['http@1.0.0||2.0.0', 'email@1.0.0||2.0.0'], 'server', { weak: true });
+  } else {
+    api.use(['http@1.0.0||2.0.0', 'email@1.0.0||2.0.0'], 'server');
+  }
   api.use(['random', 'ecmascript', 'tracker'], ['client']);
 
   // common before

--- a/package.js
+++ b/package.js
@@ -24,12 +24,12 @@ var npmModules = {
 Npm.depends(npmModules);
 
 Package.onUse(function (api) {
-  configurePackage({ api, isTesting: false });
+  configurePackage(api, false);
   api.export(['Kadira', 'Monti']);
 });
 
 Package.onTest(function (api) {
-  configurePackage({ api, isTesting: true });
+  configurePackage(api, true);
   api.use([
     'tinytest',
     'test-helpers',
@@ -93,7 +93,7 @@ Package.onTest(function (api) {
   ], ['client', 'server']);
 });
 
-function configurePackage({ api, isTesting }) {
+function configurePackage(api, isTesting) {
   api.versionsFrom('METEOR@1.4');
   api.use('montiapm:meteorx@2.2.0', ['server']);
   api.use('meteorhacks:zones@1.2.1', { weak: true });

--- a/package.js
+++ b/package.js
@@ -101,12 +101,12 @@ function configurePackage(api) {
   api.use('zodern:meteor-package-versions@0.2.0');
 
   api.use([
-    'minimongo', 'livedata', 'mongo-livedata', 'ejson', 'ddp-common',
+    'minimongo', 'ejson', 'ddp-common',
     'underscore', 'random', 'webapp', 'ecmascript'
   ], ['server']);
-  api.use('email@1.0.0||2.0.0');
-  api.use('http@1.0.0||2.0.0', 'server');
-  api.use(['random', 'localstorage', 'ecmascript', 'tracker'], ['client']);
+
+  api.use(['http@1.0.0||2.0.0', 'email@1.0.0||2.0.0', 'mongo', 'ddp'], 'server', { weak: true });
+  api.use(['random', 'ecmascript', 'tracker'], ['client']);
 
   // common before
   api.addFiles([

--- a/package.js
+++ b/package.js
@@ -23,12 +23,12 @@ var npmModules = {
 
 Npm.depends(npmModules);
 
-Package.onUse(function(api) {
+Package.onUse(function (api) {
   configurePackage(api);
   api.export(['Kadira', 'Monti']);
 });
 
-Package.onTest(function(api) {
+Package.onTest(function (api) {
   configurePackage(api, 'test');
   api.use([
     'tinytest',
@@ -83,7 +83,7 @@ Package.onTest(function(api) {
     'tests/client/error_reporters/unhandled_rejection.js',
     'tests/client/error_reporters/zone.js',
     'tests/client/error_reporters/meteor_debug.js',
-    'tests/client/error_reporters/tracker.js', 
+    'tests/client/error_reporters/tracker.js',
   ], 'client');
 
   // common after
@@ -96,19 +96,15 @@ Package.onTest(function(api) {
 function configurePackage(api, mode) {
   api.versionsFrom('METEOR@1.4');
   api.use('montiapm:meteorx@2.2.0', ['server']);
-  api.use('meteorhacks:zones@1.2.1', {weak: true});
-  api.use('simple:json-routes@2.1.0', {weak: true});
+  api.use('meteorhacks:zones@1.2.1', { weak: true });
+  api.use('simple:json-routes@2.1.0', { weak: true });
   api.use('zodern:meteor-package-versions@0.2.0');
 
   api.use([
     'minimongo', 'mongo', 'ddp', 'ejson', 'ddp-common',
     'underscore', 'random', 'webapp', 'ecmascript'
   ], ['server']);
-  if (mode !== 'test') {
-    api.use(['http@1.0.0||2.0.0', 'email@1.0.0||2.0.0'], 'server', { weak: true });
-  } else {
-    api.use(['http@1.0.0||2.0.0', 'email@1.0.0||2.0.0'], 'server');
-  }
+  api.use(['http@1.0.0||2.0.0', 'email@1.0.0||2.0.0'], 'server', { weak: mode !== 'test' });
   api.use(['random', 'ecmascript', 'tracker'], ['client']);
 
   // common before

--- a/tests/hijack/email.js
+++ b/tests/hijack/email.js
@@ -1,21 +1,23 @@
-
-Tinytest.add(
-  'Email - success',
-  function (test) {
-    EnableTrackingMethods();
-    var methodId = RegisterMethod(function () {
-      Email.send({from: 'arunoda@meteorhacks.com', to: 'hello@meteor.com'});
-    });
-    var client = GetMeteorClient();
-    var result = client.call(methodId);
-    var events = GetLastMethodEvents([0]);
-    var expected = [
-      ['start'],
-      ['wait'],
-      ['email'],
-      ['complete']
-    ];
-    test.equal(events, expected);
-    CleanTestData();
-  }
-);
+if (Package['email']) {
+  Tinytest.add(
+    'Email - success',
+    function (test) {
+      EnableTrackingMethods();
+      const Email = Package['email'].Email;
+      var methodId = RegisterMethod(function () {
+        Email.send({ from: 'arunoda@meteorhacks.com', to: 'hello@meteor.com' });
+      });
+      var client = GetMeteorClient();
+      var result = client.call(methodId);
+      var events = GetLastMethodEvents([0]);
+      var expected = [
+        ['start'],
+        ['wait'],
+        ['email'],
+        ['complete']
+      ];
+      test.equal(events, expected);
+      CleanTestData();
+    }
+  );
+}

--- a/tests/hijack/email.js
+++ b/tests/hijack/email.js
@@ -1,23 +1,21 @@
-if (Package['email']) {
-  Tinytest.add(
-    'Email - success',
-    function (test) {
-      EnableTrackingMethods();
-      const Email = Package['email'].Email;
-      var methodId = RegisterMethod(function () {
-        Email.send({ from: 'arunoda@meteorhacks.com', to: 'hello@meteor.com' });
-      });
-      var client = GetMeteorClient();
-      var result = client.call(methodId);
-      var events = GetLastMethodEvents([0]);
-      var expected = [
-        ['start'],
-        ['wait'],
-        ['email'],
-        ['complete']
-      ];
-      test.equal(events, expected);
-      CleanTestData();
-    }
-  );
-}
+Tinytest.add(
+  'Email - success',
+  function (test) {
+    EnableTrackingMethods();
+    const Email = Package['email'].Email;
+    var methodId = RegisterMethod(function () {
+      Email.send({ from: 'arunoda@meteorhacks.com', to: 'hello@meteor.com' });
+    });
+    var client = GetMeteorClient();
+    var result = client.call(methodId);
+    var events = GetLastMethodEvents([0]);
+    var expected = [
+      ['start'],
+      ['wait'],
+      ['email'],
+      ['complete']
+    ];
+    test.equal(events, expected);
+    CleanTestData();
+  }
+);

--- a/tests/hijack/error.js
+++ b/tests/hijack/error.js
@@ -57,7 +57,6 @@ Tinytest.add(
   }
 );
 
-const HTTP = Package['http'].HTTP;
 Tinytest.add(
   'Errors - Meteor._debug - do not track method errors',
   function (test) {

--- a/tests/hijack/error.js
+++ b/tests/hijack/error.js
@@ -57,58 +57,62 @@ Tinytest.add(
   }
 );
 
-Tinytest.add(
-  'Errors - Meteor._debug - do not track method errors',
-  function (test) {
-    var originalErrorTrackingStatus = Kadira.options.enableErrorTracking;
-    Kadira.enableErrorTracking();
-    Kadira.models.error = new ErrorModel('foo');
-    var method = RegisterMethod(causeError);
-    var client = GetMeteorClient();
+if (Package['http']) {
+  const HTTP = Package['http'].HTTP;
+  Tinytest.add(
+    'Errors - Meteor._debug - do not track method errors',
+    function (test) {
+      var originalErrorTrackingStatus = Kadira.options.enableErrorTracking;
+      Kadira.enableErrorTracking();
+      Kadira.models.error = new ErrorModel('foo');
+      var method = RegisterMethod(causeError);
+      var client = GetMeteorClient();
 
-    try {
-      var result = client.call(method);
-    } catch (e) {
-      // ignore the error
-    }
+      try {
+        var result = client.call(method);
+      } catch (e) {
+        // ignore the error
+      }
 
-    var payload = Kadira.models.error.buildPayload();
-    var error = payload.errors[0];
-    test.equal(1, payload.errors.length);
-    test.equal(error.type, 'method');
-    test.equal(error.subType, method);
-    _resetErrorTracking(originalErrorTrackingStatus);
-
-    function causeError () {
-      HTTP.call('POST', 'localhost', Function());
-    }
-  }
-);
-
-Tinytest.addAsync(
-  'Errors - Meteor._debug - do not track pubsub errors',
-  function (test, done) {
-    var originalErrorTrackingStatus = Kadira.options.enableErrorTracking;
-    Kadira.enableErrorTracking();
-    Kadira.models.error = new ErrorModel('foo');
-    var pubsub = RegisterPublication(causeError);
-    var client = GetMeteorClient();
-    var result = client.subscribe(pubsub, {onError: function () {
       var payload = Kadira.models.error.buildPayload();
       var error = payload.errors[0];
       test.equal(1, payload.errors.length);
-      test.equal(error.type, 'sub');
-      test.equal(error.subType, pubsub);
+      test.equal(error.type, 'method');
+      test.equal(error.subType, method);
       _resetErrorTracking(originalErrorTrackingStatus);
-      done();
-    }});
 
-    function causeError () {
-      HTTP.call('POST', 'localhost', Function());
+      function causeError () {
+        HTTP.call('POST', 'localhost', Function());
+      }
     }
-  }
-);
+  );
+}
+if (Package['http']) {
+  const HTTP = Package['http'].HTTP;
+  Tinytest.addAsync(
+    'Errors - Meteor._debug - do not track pubsub errors',
+    function (test, done) {
+      var originalErrorTrackingStatus = Kadira.options.enableErrorTracking;
+      Kadira.enableErrorTracking();
+      Kadira.models.error = new ErrorModel('foo');
+      var pubsub = RegisterPublication(causeError);
+      var client = GetMeteorClient();
+      var result = client.subscribe(pubsub, {onError: function () {
+        var payload = Kadira.models.error.buildPayload();
+        var error = payload.errors[0];
+        test.equal(1, payload.errors.length);
+        test.equal(error.type, 'sub');
+        test.equal(error.subType, pubsub);
+        _resetErrorTracking(originalErrorTrackingStatus);
+        done();
+      }});
 
+      function causeError () {
+        HTTP.call('POST', 'localhost', Function());
+      }
+    }
+  );
+}
 Tinytest.addAsync(
   'Errors - Meteor._debug - do not track when no arguments',
   function (test, done) {

--- a/tests/hijack/error.js
+++ b/tests/hijack/error.js
@@ -86,7 +86,6 @@ Tinytest.add(
   }
 );
 
-const HTTP = Package['http'].HTTP;
 Tinytest.addAsync(
   'Errors - Meteor._debug - do not track pubsub errors',
   function (test, done) {

--- a/tests/hijack/error.js
+++ b/tests/hijack/error.js
@@ -22,11 +22,11 @@ Tinytest.add(
         // at: 1408098721326,
         events: [
           ["start", 0, {}],
-          ["error", 0, {error: {message: "_debug", stack: "_stack"}}]
+          ["error", 0, { error: { message: "_debug", stack: "_stack" } }]
         ],
-        metrics: {total: 0}
+        metrics: { total: 0 }
       },
-      stacks: [{stack: "_stack"}],
+      stacks: [{ stack: "_stack" }],
       count: 1
     }
 
@@ -57,47 +57,46 @@ Tinytest.add(
   }
 );
 
-if (Package['http']) {
-  const HTTP = Package['http'].HTTP;
-  Tinytest.add(
-    'Errors - Meteor._debug - do not track method errors',
-    function (test) {
-      var originalErrorTrackingStatus = Kadira.options.enableErrorTracking;
-      Kadira.enableErrorTracking();
-      Kadira.models.error = new ErrorModel('foo');
-      var method = RegisterMethod(causeError);
-      var client = GetMeteorClient();
+const HTTP = Package['http'].HTTP;
+Tinytest.add(
+  'Errors - Meteor._debug - do not track method errors',
+  function (test) {
+    var originalErrorTrackingStatus = Kadira.options.enableErrorTracking;
+    Kadira.enableErrorTracking();
+    Kadira.models.error = new ErrorModel('foo');
+    var method = RegisterMethod(causeError);
+    var client = GetMeteorClient();
 
-      try {
-        var result = client.call(method);
-      } catch (e) {
-        // ignore the error
-      }
-
-      var payload = Kadira.models.error.buildPayload();
-      var error = payload.errors[0];
-      test.equal(1, payload.errors.length);
-      test.equal(error.type, 'method');
-      test.equal(error.subType, method);
-      _resetErrorTracking(originalErrorTrackingStatus);
-
-      function causeError () {
-        HTTP.call('POST', 'localhost', Function());
-      }
+    try {
+      var result = client.call(method);
+    } catch (e) {
+      // ignore the error
     }
-  );
-}
-if (Package['http']) {
-  const HTTP = Package['http'].HTTP;
-  Tinytest.addAsync(
-    'Errors - Meteor._debug - do not track pubsub errors',
-    function (test, done) {
-      var originalErrorTrackingStatus = Kadira.options.enableErrorTracking;
-      Kadira.enableErrorTracking();
-      Kadira.models.error = new ErrorModel('foo');
-      var pubsub = RegisterPublication(causeError);
-      var client = GetMeteorClient();
-      var result = client.subscribe(pubsub, {onError: function () {
+
+    var payload = Kadira.models.error.buildPayload();
+    var error = payload.errors[0];
+    test.equal(1, payload.errors.length);
+    test.equal(error.type, 'method');
+    test.equal(error.subType, method);
+    _resetErrorTracking(originalErrorTrackingStatus);
+
+    function causeError() {
+      HTTP.call('POST', 'localhost', Function());
+    }
+  }
+);
+
+const HTTP = Package['http'].HTTP;
+Tinytest.addAsync(
+  'Errors - Meteor._debug - do not track pubsub errors',
+  function (test, done) {
+    var originalErrorTrackingStatus = Kadira.options.enableErrorTracking;
+    Kadira.enableErrorTracking();
+    Kadira.models.error = new ErrorModel('foo');
+    var pubsub = RegisterPublication(causeError);
+    var client = GetMeteorClient();
+    var result = client.subscribe(pubsub, {
+      onError: function () {
         var payload = Kadira.models.error.buildPayload();
         var error = payload.errors[0];
         test.equal(1, payload.errors.length);
@@ -105,14 +104,15 @@ if (Package['http']) {
         test.equal(error.subType, pubsub);
         _resetErrorTracking(originalErrorTrackingStatus);
         done();
-      }});
-
-      function causeError () {
-        HTTP.call('POST', 'localhost', Function());
       }
+    });
+
+    function causeError() {
+      HTTP.call('POST', 'localhost', Function());
     }
-  );
-}
+  }
+);
+
 Tinytest.addAsync(
   'Errors - Meteor._debug - do not track when no arguments',
   function (test, done) {
@@ -141,8 +141,8 @@ if (!['1.4', '1.5', '1.6'].find(prefix => Meteor.release.startsWith(`METEOR@${pr
       console.log = function (message, loggedError) {
         origLog.apply(console, arguments);
         console.log = origLog;
-          test.equal(error.message, loggedError.message);
-          test.equal(error.stack, loggedError.stack);
+        test.equal(error.message, loggedError.message);
+        test.equal(error.stack, loggedError.stack);
         _resetErrorTracking(originalErrorTrackingStatus);
         done();
       }
@@ -229,16 +229,16 @@ Tinytest.addAsync(
     var client = GetMeteorClient();
     try {
       var result = client.call(methodId);
-    } catch(ex) {
+    } catch (ex) {
       var errorMessage = 'reason [ERR_CODE]'
       test.equal(ex.message, errorMessage);
       var payload = Kadira.models.error.buildPayload();
       var error = payload.errors[0];
       test.isTrue(error.stacks[0].stack.indexOf(errorMessage) >= 0);
 
-      var lastEvent = error.trace.events[error.trace.events.length -1];
-      test.isTrue(lastEvent[2].error.message.indexOf(errorMessage) >=0);
-      test.isTrue(lastEvent[2].error.stack.indexOf(errorMessage) >=0);
+      var lastEvent = error.trace.events[error.trace.events.length - 1];
+      test.isTrue(lastEvent[2].error.message.indexOf(errorMessage) >= 0);
+      test.isTrue(lastEvent[2].error.stack.indexOf(errorMessage) >= 0);
       done();
     }
 
@@ -256,17 +256,17 @@ Tinytest.addAsync(
     var client = GetMeteorClient();
     try {
       var result = client.call(methodId);
-    } catch(ex) {
+    } catch (ex) {
       var errorMessage = 'reason [ERR_CODE]'
       test.equal(ex.message, errorMessage);
       var payload = Kadira.models.error.buildPayload();
       var error = payload.errors[0];
       test.isTrue(error.stacks[0].stack.indexOf(errorMessage) >= 0);
 
-      var lastEvent = error.trace.events[error.trace.events.length -1];
+      var lastEvent = error.trace.events[error.trace.events.length - 1];
       console.dir(lastEvent);
-      test.isTrue(lastEvent[2].error.message.indexOf(errorMessage) >=0);
-      test.isTrue(lastEvent[2].error.stack.indexOf(errorMessage) >=0);
+      test.isTrue(lastEvent[2].error.message.indexOf(errorMessage) >= 0);
+      test.isTrue(lastEvent[2].error.stack.indexOf(errorMessage) >= 0);
       test.equal(lastEvent[2].error.details, "details");
       done();
     }
@@ -285,16 +285,16 @@ Tinytest.addAsync(
     var client = GetMeteorClient();
     try {
       var result = client.call(methodId);
-    } catch(ex) {
+    } catch (ex) {
       var errorMessage = 'the-message';
       test.isTrue(ex.message.match(/Internal server error/));
       var payload = Kadira.models.error.buildPayload();
       var error = payload.errors[0];
       test.isTrue(error.stacks[0].stack.indexOf(errorMessage) >= 0);
 
-      var lastEvent = error.trace.events[error.trace.events.length -1];
-      test.isTrue(lastEvent[2].error.message.indexOf(errorMessage) >=0);
-      test.isTrue(lastEvent[2].error.stack.indexOf(errorMessage) >=0);
+      var lastEvent = error.trace.events[error.trace.events.length - 1];
+      test.isTrue(lastEvent[2].error.message.indexOf(errorMessage) >= 0);
+      test.isTrue(lastEvent[2].error.stack.indexOf(errorMessage) >= 0);
       done();
     }
 
@@ -302,8 +302,8 @@ Tinytest.addAsync(
   }
 );
 
-function _resetErrorTracking (status) {
-  if(status) {
+function _resetErrorTracking(status) {
+  if (status) {
     Kadira.enableErrorTracking();
   } else {
     Kadira.disableErrorTracking();

--- a/tests/hijack/http.js
+++ b/tests/hijack/http.js
@@ -1,28 +1,26 @@
-if (Package['http']) {
-  const HTTP = Package['http'].HTTP;
-  Tinytest.add(
-    'HTTP - call a server',
-    function (test) {
-      EnableTrackingMethods();
-      var methodId = RegisterMethod(function () {
-        var result = HTTP.get('http://localhost:3301');
-        return result.statusCode;
-      });
-      var client = GetMeteorClient();
-      var result = client.call(methodId);
-      var events = GetLastMethodEvents([0, 2]);
-      var expected = [
-        ['start',,{userId: null, params: '[]'}],
-        ['wait',,{waitOn: []}],
-        ['http',,{url: 'http://localhost:3301', method: 'GET', statusCode: 200}],
-        ['complete']
-      ];
-      test.equal(events, expected);
-      test.equal(result, 200);
-      CleanTestData();
-    }
-  );
-}
+Tinytest.add(
+  'HTTP - call a server',
+  function (test) {
+    EnableTrackingMethods();
+    var methodId = RegisterMethod(function () {
+      var result = HTTP.get('http://localhost:3301');
+      return result.statusCode;
+    });
+    var client = GetMeteorClient();
+    var result = client.call(methodId);
+    var events = GetLastMethodEvents([0, 2]);
+    var expected = [
+      ['start', , { userId: null, params: '[]' }],
+      ['wait', , { waitOn: [] }],
+      ['http', , { url: 'http://localhost:3301', method: 'GET', statusCode: 200 }],
+      ['complete']
+    ];
+    test.equal(events, expected);
+    test.equal(result, 200);
+    CleanTestData();
+  }
+);
+
 
 Tinytest.add(
   'HTTP - async callback',
@@ -32,7 +30,7 @@ Tinytest.add(
       var Future = Npm.require('fibers/future');
       var f = new Future();
       var result;
-      HTTP.get('http://localhost:3301', function(err, res) {
+      HTTP.get('http://localhost:3301', function (err, res) {
         result = res;
         f.return();
       });
@@ -43,10 +41,10 @@ Tinytest.add(
     var result = client.call(methodId);
     var events = GetLastMethodEvents([0, 2]);
     var expected = [
-      ['start',,{userId: null, params: '[]'}],
-      ['wait',,{waitOn: []}],
-      ['http',,{url: 'http://localhost:3301', method: 'GET', async: true}],
-      ['async',, {}],
+      ['start', , { userId: null, params: '[]' }],
+      ['wait', , { waitOn: [] }],
+      ['http', , { url: 'http://localhost:3301', method: 'GET', async: true }],
+      ['async', , {}],
       ['complete']
     ];
     test.equal(events, expected);

--- a/tests/hijack/http.js
+++ b/tests/hijack/http.js
@@ -1,26 +1,28 @@
-
-Tinytest.add(
-  'HTTP - call a server',
-  function (test) {
-    EnableTrackingMethods();
-    var methodId = RegisterMethod(function () {
-      var result = HTTP.get('http://localhost:3301');
-      return result.statusCode;
-    });
-    var client = GetMeteorClient();
-    var result = client.call(methodId);
-    var events = GetLastMethodEvents([0, 2]);
-    var expected = [
-      ['start',,{userId: null, params: '[]'}],
-      ['wait',,{waitOn: []}],
-      ['http',,{url: 'http://localhost:3301', method: 'GET', statusCode: 200}],
-      ['complete']
-    ];
-    test.equal(events, expected);
-    test.equal(result, 200);
-    CleanTestData();
-  }
-);
+if (Package['http']) {
+  const HTTP = Package['http'].HTTP;
+  Tinytest.add(
+    'HTTP - call a server',
+    function (test) {
+      EnableTrackingMethods();
+      var methodId = RegisterMethod(function () {
+        var result = HTTP.get('http://localhost:3301');
+        return result.statusCode;
+      });
+      var client = GetMeteorClient();
+      var result = client.call(methodId);
+      var events = GetLastMethodEvents([0, 2]);
+      var expected = [
+        ['start',,{userId: null, params: '[]'}],
+        ['wait',,{waitOn: []}],
+        ['http',,{url: 'http://localhost:3301', method: 'GET', statusCode: 200}],
+        ['complete']
+      ];
+      test.equal(events, expected);
+      test.equal(result, 200);
+      CleanTestData();
+    }
+  );
+}
 
 Tinytest.add(
   'HTTP - async callback',


### PR DESCRIPTION
- Weaken `HTTP` and `Email` packages.
- Remove `localstorage` package and rely on browser localstorage. Optional chaining is used so in case it's not found, it'd return false and not log which is an okay trade off.
- Replace `livedata` and `mongo-livedata` with `ddp` and `mongo` packages respectively as they were both internally implying the other two packages.