### PR TITLE
decrease execution time limit for job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
@@ -25,7 +26,7 @@ jobs:
           - '--release 2.5.6'
           - '--release 2.6'
           # Latest version
-          - 
+          -
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
To fail faster.

Parameter description: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes