### PR TITLE
Oplog Disabled Reasons Overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ smart.lock
 versions.json
 .idea
 .eslintcache
+.envrc

--- a/lib/check_for_oplog.js
+++ b/lib/check_for_oplog.js
@@ -19,6 +19,7 @@ OplogCheck.env = function () {
 OplogCheck.disableOplog = function (cursorDescription) {
   const { options } = cursorDescription;
 
+  // Underscored version for Meteor pre 1.2
   if (options._disableOplog || options.disableOplog) {
     return {
       code: 'DISABLE_OPLOG',
@@ -72,6 +73,7 @@ OplogCheck.miniMongoSorter = function (cursorDescription) {
 OplogCheck.fields = function (cursorDescription) {
   let options = cursorDescription.options;
 
+  // Checking `projection` for Meteor 2.6+
   const fields = options.fields || options.projection;
 
   if (fields) {

--- a/lib/check_for_oplog.js
+++ b/lib/check_for_oplog.js
@@ -15,7 +15,9 @@ OplogCheck.env = function () {
 };
 
 OplogCheck.disableOplog = function (cursorDescription) {
-  if (cursorDescription.options._disableOplog) {
+  const { options } = cursorDescription;
+
+  if (options._disableOplog || options.disableOplog) {
     return {
       code: 'DISABLE_OPLOG',
       reason: "You've disabled oplog for this cursor explicitly with _disableOplog option."
@@ -67,9 +69,12 @@ OplogCheck.miniMongoSorter = function (cursorDescription) {
 
 OplogCheck.fields = function (cursorDescription) {
   let options = cursorDescription.options;
-  if (options.fields) {
+
+  const fields = options.fields || options.projection;
+
+  if (fields) {
     try {
-      LocalCollection._checkSupportedProjection(options.fields);
+      LocalCollection._checkSupportedProjection(fields);
       return true;
     } catch (e) {
       if (e.name === 'MinimongoError') {
@@ -169,7 +174,7 @@ Kadira.checkWhyNoOplog = function (cursorDescription, observerDriver) {
   if (typeof Minimongo === 'undefined') {
     return {
       code: 'CANNOT_DETECT',
-      reason: "You are running an older Meteor version and Kadira can't check oplog state.",
+      reason: "You are running an older Meteor version and Monti APM can't check oplog state.",
       solution: 'Try updating your Meteor app'
     };
   }

--- a/lib/check_for_oplog.js
+++ b/lib/check_for_oplog.js
@@ -1,5 +1,7 @@
 /* global Minimongo, LocalCollection, OplogCheck */
 
+import { Tracker } from 'meteor/tracker';
+
 // expose for testing purpose
 OplogCheck = {};
 
@@ -143,12 +145,23 @@ OplogCheck.limitButNoSort = function (cursorDescription) {
   return true;
 };
 
-OplogCheck.olderVersion = function (cursorDescription, driver) {
-  if (driver && !driver.constructor.cursorSupported) {
+OplogCheck.thirdParty = function (cursorDescription, observerDriver) {
+  if (Tracker.active && observerDriver.constructor.name !== 'OplogObserveDriver') {
     return {
-      code: 'OLDER_VERSION',
-      reason: 'Your Meteor version does not have oplog support.',
-      solution: 'Upgrade your app to Meteor version 1.4 or later.'
+      code: 'TRACKER_ACTIVE',
+      reason: 'Observe driver detected inside an active tracker, you might be using a third party library (e.g "reactive-mongo").',
+      solution: 'Check the library documentation, perhaps an option is missing.'
+    };
+  }
+  return true;
+};
+
+OplogCheck.unknownReason = function (cursorDescription, driver) {
+  if (driver && driver.constructor.name !== 'OplogObserveDriver') {
+    return {
+      code: 'UNKNOWN_REASON',
+      reason: 'Not using the Oplog Observe Driver for unknown reason.',
+      solution: 'Check your third-party libraries.'
     };
   }
   return true;
@@ -167,7 +180,8 @@ let globalMatchers = [
   OplogCheck.geo,
   OplogCheck.limitButNoSort,
   OplogCheck.miniMongoSorter,
-  OplogCheck.olderVersion,
+  OplogCheck.thirdParty,
+  OplogCheck.unknownReason,
 ];
 
 Kadira.checkWhyNoOplog = function (cursorDescription, observerDriver) {
@@ -181,11 +195,15 @@ Kadira.checkWhyNoOplog = function (cursorDescription, observerDriver) {
 
   let result = runMatchers(preRunningMatchers, cursorDescription, observerDriver);
 
+  console.log(result);
+
   if (result !== true) {
     return result;
   }
 
   result = runMatchers(globalMatchers, cursorDescription, observerDriver);
+
+  console.log(result);
 
   if (result !== true) {
     return result;

--- a/lib/check_for_oplog.js
+++ b/lib/check_for_oplog.js
@@ -195,15 +195,11 @@ Kadira.checkWhyNoOplog = function (cursorDescription, observerDriver) {
 
   let result = runMatchers(preRunningMatchers, cursorDescription, observerDriver);
 
-  console.log(result);
-
   if (result !== true) {
     return result;
   }
 
   result = runMatchers(globalMatchers, cursorDescription, observerDriver);
-
-  console.log(result);
 
   if (result !== true) {
     return result;

--- a/lib/check_for_oplog.js
+++ b/lib/check_for_oplog.js
@@ -1,66 +1,7 @@
-/* global Minimongo, LocalCollection */
-
-import { Meteor } from 'meteor/meteor';
-import { _ } from 'meteor/underscore';
+/* global Minimongo, LocalCollection, OplogCheck */
 
 // expose for testing purpose
 OplogCheck = {};
-
-OplogCheck._070 = function (cursorDescription) {
-  let options = cursorDescription.options;
-  if (options.limit) {
-    return {
-      code: '070_LIMIT_NOT_SUPPORTED',
-      reason: 'Meteor 0.7.0 does not support limit with oplog.',
-      solution: 'Upgrade your app to Meteor version 0.7.2 or later.'
-    };
-  }
-
-  let exists$ = _.any(cursorDescription.selector, function (value, field) {
-    if (field.substr(0, 1) === '$') { return true; }
-  });
-
-  if (exists$) {
-    return {
-      code: '070_$_NOT_SUPPORTED',
-      reason: 'Meteor 0.7.0 supports only equal checks with oplog.',
-      solution: 'Upgrade your app to Meteor version 0.7.2 or later.'
-    };
-  }
-
-  let onlyScalers = _.all(cursorDescription.selector, function (value, field) {
-    return typeof value === 'string' ||
-      typeof value === 'number' ||
-      typeof value === 'boolean' ||
-      value === null ||
-      value instanceof Meteor.Collection.ObjectID;
-  });
-
-  if (!onlyScalers) {
-    return {
-      code: '070_ONLY_SCALERS',
-      reason: 'Meteor 0.7.0 only supports scalers as comparators.',
-      solution: 'Upgrade your app to Meteor version 0.7.2 or later.'
-    };
-  }
-
-  return true;
-};
-
-OplogCheck._071 = function (cursorDescription) {
-  let options = cursorDescription.options;
-  let matcher = new Minimongo.Matcher(cursorDescription.selector);
-  if (options.limit) {
-    return {
-      code: '071_LIMIT_NOT_SUPPORTED',
-      reason: 'Meteor 0.7.1 does not support limit with oplog.',
-      solution: 'Upgrade your app to Meteor version 0.7.2 or later.'
-    };
-  }
-
-  return true;
-};
-
 
 OplogCheck.env = function () {
   if (!process.env.MONGO_OPLOG_URL) {
@@ -77,7 +18,7 @@ OplogCheck.disableOplog = function (cursorDescription) {
   if (cursorDescription.options._disableOplog) {
     return {
       code: 'DISABLE_OPLOG',
-      reason: "You've disable oplog for this cursor explicitly with _disableOplog option."
+      reason: "You've disabled oplog for this cursor explicitly with _disableOplog option."
     };
   }
   return true;
@@ -202,18 +143,7 @@ OplogCheck.olderVersion = function (cursorDescription, driver) {
     return {
       code: 'OLDER_VERSION',
       reason: 'Your Meteor version does not have oplog support.',
-      solution: 'Upgrade your app to Meteor version 0.7.2 or later.'
-    };
-  }
-  return true;
-};
-
-OplogCheck.gitCheckout = function (cursorDescription, driver) {
-  if (!Meteor.release) {
-    return {
-      code: 'GIT_CHECKOUT',
-      reason: "Seems like your Meteor version is based on a Git checkout and it doesn't have the oplog support.",
-      solution: 'Try to upgrade your Meteor version.'
+      solution: 'Upgrade your app to Meteor version 1.4 or later.'
     };
   }
   return true;
@@ -233,12 +163,6 @@ let globalMatchers = [
   OplogCheck.limitButNoSort,
   OplogCheck.miniMongoSorter,
   OplogCheck.olderVersion,
-  OplogCheck.gitCheckout
-];
-
-let versionMatchers = [
-  [/^0\.7\.1/, OplogCheck._071],
-  [/^0\.7\.0/, OplogCheck._070],
 ];
 
 Kadira.checkWhyNoOplog = function (cursorDescription, observerDriver) {
@@ -251,22 +175,13 @@ Kadira.checkWhyNoOplog = function (cursorDescription, observerDriver) {
   }
 
   let result = runMatchers(preRunningMatchers, cursorDescription, observerDriver);
+
   if (result !== true) {
     return result;
   }
 
-  const meteorVersion = Meteor.release;
-  for (let lc = 0; lc < versionMatchers.length; lc++) {
-    const matcherInfo = versionMatchers[lc];
-    if (matcherInfo[0].test(meteorVersion)) {
-      const matched = matcherInfo[1](cursorDescription, observerDriver);
-      if (matched !== true) {
-        return matched;
-      }
-    }
-  }
-
   result = runMatchers(globalMatchers, cursorDescription, observerDriver);
+
   if (result !== true) {
     return result;
   }
@@ -279,12 +194,13 @@ Kadira.checkWhyNoOplog = function (cursorDescription, observerDriver) {
 };
 
 function runMatchers (matcherList, cursorDescription, observerDriver) {
-  for (let lc = 0; lc < matcherList.length; lc++) {
-    const matcher = matcherList[lc];
+  for (const matcher of matcherList) {
     const matched = matcher(cursorDescription, observerDriver);
+
     if (matched !== true) {
       return matched;
     }
   }
+
   return true;
 }

--- a/lib/check_for_oplog.js
+++ b/lib/check_for_oplog.js
@@ -162,7 +162,7 @@ OplogCheck.unknownReason = function (cursorDescription, driver) {
   if (driver && driver.constructor.name !== 'OplogObserveDriver') {
     return {
       code: 'UNKNOWN_REASON',
-      reason: 'Not using the Oplog Observe Driver for unknown reason.',
+      reason: `Not using the Oplog Observe Driver for unknown reason. Driver: ${driver.constructor.name}`,
       solution: 'Check your third-party libraries.'
     };
   }

--- a/lib/hijack/db.js
+++ b/lib/hijack/db.js
@@ -174,8 +174,8 @@ hijackDBOps = function hijackDBOps () {
             if (observerDriver) {
               observerDriver = ret._multiplexer._observeDriver;
               let observerDriverClass = observerDriver.constructor;
-              let usesOplog = typeof observerDriverClass.cursorSupported === 'function';
-              endData.oplog = usesOplog;
+              endData.oplog = typeof observerDriverClass.cursorSupported === 'function';
+
               let size = 0;
               ret._multiplexer._cache.docs.forEach(function () { size++; });
               endData.noOfCachedDocs = size;

--- a/lib/hijack/db.js
+++ b/lib/hijack/db.js
@@ -160,7 +160,8 @@ hijackDBOps = function hijackDBOps () {
         let ret = originalFunc.apply(this, arguments);
 
         let endData = {};
-        if (type == 'observeChanges' || type == 'observe') {
+
+        if (type === 'observeChanges' || type === 'observe') {
           let observerDriver;
           endData.oplog = false;
           // get data written by the multiplexer
@@ -194,12 +195,12 @@ hijackDBOps = function hijackDBOps () {
             endData.noOplogReason = reasonInfo.reason;
             endData.noOplogSolution = reasonInfo.solution;
           }
-        } else if (type == 'fetch' || type == 'map') {
+        } else if (type === 'fetch' || type === 'map') {
           // for other cursor operation
 
           endData.docsFetched = ret.length;
 
-          if (type == 'fetch') {
+          if (type === 'fetch') {
             let coll = cursorDescription.collectionName;
             let query = cursorDescription.selector;
             let opts = cursorDescription.options;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1350,9 +1350,9 @@
       }
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"

--- a/package.js
+++ b/package.js
@@ -33,6 +33,7 @@ Package.onUse(function (api) {
 Package.onTest(function (api) {
   configurePackage(api, true);
   api.use([
+    'peerlibrary:reactive-publish',
     'tinytest',
     'test-helpers',
   ], ['client', 'server']);

--- a/tests/check_for_oplog.js
+++ b/tests/check_for_oplog.js
@@ -191,32 +191,21 @@ Tinytest.add(
 );
 
 Tinytest.add(
-  'CheckForOplog - OplogCheck.olderVersion - older version',
+  'CheckForOplog - OplogCheck.unknownReason - unknown reason',
   function (test) {
     var driver = function() {};
-    test.equal(OplogCheck.olderVersion(null, driver).code, "OLDER_VERSION");
-  }
-);
-
-Tinytest.add(
-  'CheckForOplog - OplogCheck.olderVersion - newer version',
-  function (test) {
-    function Observer() {};
-    Observer.cursorSupported = function() {}
-
-    var driver = new Observer();
-    test.equal(OplogCheck.olderVersion(null, driver), true);
+    test.equal(OplogCheck.unknownReason(null, driver).code, "UNKNOWN_REASON");
   }
 );
 
 Tinytest.add(
   'CheckForOplog - Kadira.checkWhyNoOplog - no env',
   function (test) {
-
     var result = Kadira.checkWhyNoOplog({
       selector: {aa: {$gt: 20}},
       options: {limit: 20},
     });
+
     test.equal(result.code, 'NO_ENV');
   }
 );
@@ -237,17 +226,18 @@ Tinytest.addAsync(
 );
 
 Tinytest.addAsync(
-  'CheckForOplog - Kadira.checkWhyNoOplog - supportting query',
+  'CheckForOplog - Kadira.checkWhyNoOplog - supporting query',
   function (test, done) {
-    function Observer() {};
-    Observer.cursorSupported = function() {}
-    var driver = new Observer();
+    function OplogObserveDriver() {};
+    OplogObserveDriver.cursorSupported = function() {}
+    var driver = new OplogObserveDriver();
 
     WithMongoOplogUrl(function() {
       var result = Kadira.checkWhyNoOplog({
         selector: {aa: {$gt: 20}},
         options: {limit: 20, sort: {aa: 1}},
       }, driver);
+
       test.equal(result.code, 'OPLOG_SUPPORTED');
       done();
     });

--- a/tests/check_for_oplog.js
+++ b/tests/check_for_oplog.js
@@ -25,8 +25,6 @@ Tinytest.addAsync('CheckForOplog - Kadira.checkWhyNoOplog - reactive publish', f
 
   const sub = SubscribeAndWait(client, pubId);
 
-  console.log(observeChangesEvent);
-
   const { data } = observeChangesEvent;
 
   test.equal(data.oplog, false);

--- a/tests/check_for_oplog.js
+++ b/tests/check_for_oplog.js
@@ -3,65 +3,6 @@ if(typeof Minimongo == 'undefined') {
 }
 
 Tinytest.add(
-  'CheckForOplog - OplogCheck._070 - no limit supported',
-  function (test) {
-    test.equal(OplogCheck._070({
-      options: {limit: 20}
-    }).code, '070_LIMIT_NOT_SUPPORTED');
-  }
-);
-
-Tinytest.add(
-  'CheckForOplog - OplogCheck._070 - $ operators',
-  function (test) {
-    test.equal(OplogCheck._070({
-      options: {},
-      selector: {$and: {}}
-    }).code, '070_$_NOT_SUPPORTED');
-  }
-);
-
-Tinytest.add(
-  'CheckForOplog - OplogCheck._070 - not scaler values',
-  function (test) {
-    test.equal(OplogCheck._070({
-      options: {},
-      selector: {aa: {$gt: 20}}
-    }).code, '070_ONLY_SCALERS');
-  }
-);
-
-Tinytest.add(
-  'CheckForOplog - OplogCheck._070 - support oplog',
-  function (test) {
-    test.equal(OplogCheck._070({
-      options: {},
-      selector: {}
-    }), true);
-  }
-);
-
-
-Tinytest.add(
-  'CheckForOplog - OplogCheck._071 - no limit supported',
-  function (test) {
-    test.equal(OplogCheck._071({
-      options: {limit: 20}
-    }).code, '071_LIMIT_NOT_SUPPORTED');
-  }
-);
-
-Tinytest.add(
-  'CheckForOplog - OplogCheck._071 - supports oplog',
-  function (test) {
-    test.equal(OplogCheck._071({
-      options: {},
-      selector: {aa: {$gt: 20}}
-    }), true);
-  }
-);
-
-Tinytest.add(
   'CheckForOplog - OplogCheck.env - MONGO_OPLOG_URL exists',
   function (test) {
     WithMongoOplogUrl(function() {

--- a/tests/check_for_oplog.js
+++ b/tests/check_for_oplog.js
@@ -269,61 +269,6 @@ Tinytest.add(
 );
 
 Tinytest.add(
-  'CheckForOplog - OplogCheck.gitCheckout - meteor version',
-  function (test) {
-    test.equal(OplogCheck.gitCheckout(), true);
-  }
-);
-
-Tinytest.add(
-  'CheckForOplog - OplogCheck.gitCheckout - cloned from git',
-  function (test) {
-    var originalRelease = Meteor.release;
-    Meteor.release = null;
-    test.equal(OplogCheck.gitCheckout().code, 'GIT_CHECKOUT');
-    Meteor.release = originalRelease;
-  }
-);
-
-Tinytest.addAsync(
-  'CheckForOplog - Kadira.checkWhyNoOplog - version 0.7.0',
-  function (test, done) {
-    var originalRelease = Meteor.release;
-    Meteor.release = "0.7.0.1";
-
-    WithMongoOplogUrl(function() {
-      var result = Kadira.checkWhyNoOplog({
-        selector: {aa: {$gt: 20}},
-        options: {}
-      });
-      test.equal(result.code, '070_ONLY_SCALERS');
-      done();
-    });
-
-    Meteor.release = originalRelease;
-  }
-);
-
-Tinytest.addAsync(
-  'CheckForOplog - Kadira.checkWhyNoOplog - version 0.7.1',
-  function (test, done) {
-    var originalRelease = Meteor.release;
-    Meteor.release = "0.7.1";
-
-    WithMongoOplogUrl(function () {
-      var result = Kadira.checkWhyNoOplog({
-        selector: {aa: {$gt: 20}},
-        options: {limit: 20}
-      });
-      test.equal(result.code, '071_LIMIT_NOT_SUPPORTED');
-      done();
-    });
-
-    Meteor.release = originalRelease;
-  }
-);
-
-Tinytest.add(
   'CheckForOplog - Kadira.checkWhyNoOplog - no env',
   function (test) {
 
@@ -367,26 +312,6 @@ Tinytest.addAsync(
     });
   }
 );
-
-Tinytest.addAsync(
-  'CheckForOplog - Kadira.checkWhyNoOplog - with invalid MiniMongo.Matcher',
-  function (test, done) {
-    var originalRelease = Meteor.release;
-    Meteor.release = "0.7.1";
-
-    WithMongoOplogUrl(function () {
-      var result = Kadira.checkWhyNoOplog({
-        selector: {aa: {$in: null}},
-        options: {limit: 20}
-      });
-      test.equal(result.code, 'MINIMONGO_MATCHER_ERROR');
-      done();
-    });
-
-    Meteor.release = originalRelease;
-  }
-);
-
 
 function WithMongoOplogUrl(fn) {
   process.env.MONGO_OPLOG_URL="mongodb://ssdsd";

--- a/tests/check_for_oplog.js
+++ b/tests/check_for_oplog.js
@@ -1,11 +1,7 @@
-if(typeof Minimongo == 'undefined') {
-  return;
-}
-
 Tinytest.add(
   'CheckForOplog - OplogCheck.env - MONGO_OPLOG_URL exists',
   function (test) {
-    WithMongoOplogUrl(function() {
+    WithMongoOplogUrl(function () {
       test.equal(OplogCheck.env(), true);
     });
   }
@@ -28,7 +24,7 @@ Tinytest.add(
 Tinytest.add(
   'CheckForOplog - OplogCheck.disableOplog - with _disableOplog',
   function (test) {
-    var result = OplogCheck.disableOplog({options: {_disableOplog: true}});
+    let result = OplogCheck.disableOplog({options: {_disableOplog: true}});
     test.equal(result.code, 'DISABLE_OPLOG');
   }
 );
@@ -47,7 +43,7 @@ Tinytest.add(
 Tinytest.add(
   'CheckForOplog - OplogCheck.miniMongoMatcher - no MiniMongo.Matcher',
   function (test) {
-    var originalMiniMongoMatcher = Minimongo.Matcher;
+    let originalMiniMongoMatcher = Minimongo.Matcher;
     Minimongo.Matcher = null;
     test.equal(OplogCheck.miniMongoMatcher({
       options: {},
@@ -61,7 +57,7 @@ Tinytest.add(
 Tinytest.add(
   'CheckForOplog - OplogCheck.miniMongoMatcher - with incorrect selector',
   function (test) {
-    var result = OplogCheck.miniMongoMatcher({
+    let result = OplogCheck.miniMongoMatcher({
       options: {},
       selector: {aa: {$in: null}}
     });
@@ -90,7 +86,7 @@ Tinytest.add(
   function (test) {
     test.equal(OplogCheck.fields({options: {
       fields: {$elemMatch: {aa: 10}}
-    }}).code, "NOT_SUPPORTED_FIELDS");
+    }}).code, 'NOT_SUPPORTED_FIELDS');
   }
 );
 
@@ -100,7 +96,7 @@ Tinytest.add(
   function (test) {
     test.equal(OplogCheck.skip({options: {
       skip: 10
-    }}).code, "SKIP_NOT_SUPPORTED");
+    }}).code, 'SKIP_NOT_SUPPORTED');
   }
 );
 
@@ -117,8 +113,8 @@ Tinytest.add(
   'CheckForOplog - OplogCheck.where - with having where',
   function (test) {
     test.equal(OplogCheck.where({selector: {
-      $where: function() {}
-    }}).code, "WHERE_NOT_SUPPORTED");
+      $where () {}
+    }}).code, 'WHERE_NOT_SUPPORTED');
   }
 );
 
@@ -136,7 +132,7 @@ Tinytest.add(
   function (test) {
     test.equal(OplogCheck.geo({selector: {
       loc: {$near: [50, 50]}
-    }}).code, "GEO_NOT_SUPPORTED");
+    }}).code, 'GEO_NOT_SUPPORTED');
   }
 );
 
@@ -154,7 +150,7 @@ Tinytest.add(
   function (test) {
     test.equal(OplogCheck.limitButNoSort({options: {
       limit: 20
-    }}).code, "LIMIT_NO_SORT");
+    }}).code, 'LIMIT_NO_SORT');
   }
 );
 
@@ -171,11 +167,11 @@ Tinytest.add(
 Tinytest.add(
   'CheckForOplog - OplogCheck.miniMongoSorter - supported sort specifier',
   function (test) {
-    var result = OplogCheck.miniMongoSorter({
+    let result = OplogCheck.miniMongoSorter({
       selector: {},
       options: {
         sort: {aa: 1}
-    }});
+      }});
     test.equal(result, true);
   }
 );
@@ -183,25 +179,25 @@ Tinytest.add(
 Tinytest.add(
   'CheckForOplog - OplogCheck.miniMongoSorter - unsupported sort specifier',
   function (test) {
-    var result = OplogCheck.miniMongoSorter({options: {
+    let result = OplogCheck.miniMongoSorter({options: {
       sort: {$natural: 1}
     }});
-    test.equal(result.code, "MINIMONGO_SORTER_ERROR");
+    test.equal(result.code, 'MINIMONGO_SORTER_ERROR');
   }
 );
 
 Tinytest.add(
   'CheckForOplog - OplogCheck.unknownReason - unknown reason',
   function (test) {
-    var driver = function() {};
-    test.equal(OplogCheck.unknownReason(null, driver).code, "UNKNOWN_REASON");
+    let driver = function () {};
+    test.equal(OplogCheck.unknownReason(null, driver).code, 'UNKNOWN_REASON');
   }
 );
 
 Tinytest.add(
   'CheckForOplog - Kadira.checkWhyNoOplog - no env',
   function (test) {
-    var result = Kadira.checkWhyNoOplog({
+    let result = Kadira.checkWhyNoOplog({
       selector: {aa: {$gt: 20}},
       options: {limit: 20},
     });
@@ -213,9 +209,8 @@ Tinytest.add(
 Tinytest.addAsync(
   'CheckForOplog - Kadira.checkWhyNoOplog - limitNoSort',
   function (test, done) {
-
-    WithMongoOplogUrl(function() {
-      var result = Kadira.checkWhyNoOplog({
+    WithMongoOplogUrl(function () {
+      let result = Kadira.checkWhyNoOplog({
         selector: {aa: {$gt: 20}},
         options: {limit: 20},
       });
@@ -228,12 +223,12 @@ Tinytest.addAsync(
 Tinytest.addAsync(
   'CheckForOplog - Kadira.checkWhyNoOplog - supporting query',
   function (test, done) {
-    function OplogObserveDriver() {};
-    OplogObserveDriver.cursorSupported = function() {}
-    var driver = new OplogObserveDriver();
+    function OplogObserveDriver () {}
+    OplogObserveDriver.cursorSupported = function () {};
+    let driver = new OplogObserveDriver();
 
-    WithMongoOplogUrl(function() {
-      var result = Kadira.checkWhyNoOplog({
+    WithMongoOplogUrl(function () {
+      let result = Kadira.checkWhyNoOplog({
         selector: {aa: {$gt: 20}},
         options: {limit: 20, sort: {aa: 1}},
       }, driver);
@@ -244,7 +239,7 @@ Tinytest.addAsync(
   }
 );
 
-Tinytest.add('CheckForOplog - Kadira.checkWhyNoOplog - reactive publish', function (test){
+Tinytest.add('CheckForOplog - Kadira.checkWhyNoOplog - reactive publish', function (test) {
   CleanTestData();
 
   let observeChangesEvent;
@@ -264,7 +259,7 @@ Tinytest.add('CheckForOplog - Kadira.checkWhyNoOplog - reactive publish', functi
       observeChangesEvent = _.first(event.nested);
 
       return TestData.find({});
-    })
+    });
   });
 
   const client = GetMeteorClient();
@@ -278,10 +273,10 @@ Tinytest.add('CheckForOplog - Kadira.checkWhyNoOplog - reactive publish', functi
 
   test.equal(observeChangesEvent.data.func, 'observeChanges');
   test.equal(observeChangesEvent.data.noOplogCode, 'TRACKER_ACTIVE');
-})
+});
 
-function WithMongoOplogUrl(fn) {
-  process.env.MONGO_OPLOG_URL="mongodb://ssdsd";
+function WithMongoOplogUrl (fn) {
+  process.env.MONGO_OPLOG_URL = 'mongodb://ssdsd';
   fn();
   delete process.env.MONGO_OPLOG_URL;
 }


### PR DESCRIPTION
- Removed oplog checks for old versions since we don't support versions that old anyways.
- Adjust checks to match changes inside the Meteor repo itself.
- Add check for when an observe driver is used inside an active tracker as it is not common and can only happen when using a library in the server.
- Adjust message for the last possible case to be "unknown" instead of mentioning the version as, all versions supported by the agent should support it.