### PR TITLE
Tracer adjustments part 2

### DIFF
--- a/lib/tracer/tracer.js
+++ b/lib/tracer/tracer.js
@@ -348,7 +348,13 @@ Tracer.prototype.optimizeEvent = function (objectEvent, prevEnded, metrics) {
     }
 
     if (this._hasUsefulNested(objectEvent)) {
+      let nestedStartedAt = nested[0].at;
+      let beginningCompute = nestedStartedAt - at;
       extraInfo.nested = this.optimizeEvents(nested, metrics);
+
+      if (beginningCompute > 0) {
+        extraInfo.nested.unshift(['compute', beginningCompute]);
+      }
     }
   }
 

--- a/lib/tracer/tracer.js
+++ b/lib/tracer/tracer.js
@@ -170,7 +170,7 @@ Tracer.prototype.asyncEvent = function (type, data, meta, fn) {
   const { info } = getStore();
 
   if (!info) {
-    return Reflect.apply(fn, this, [false]);
+    return fn(false);
   }
 
   const event = this.event(info.trace, type, data, meta);
@@ -179,7 +179,7 @@ Tracer.prototype.asyncEvent = function (type, data, meta, fn) {
   let result;
 
   try {
-    result = Reflect.apply(fn, this, [event]);
+    result = fn(event);
   } catch (err) {
     this.eventEnd(info.trace, event, { err: err.message });
     throw err;

--- a/lib/tracer/tracer.js
+++ b/lib/tracer/tracer.js
@@ -206,7 +206,6 @@ Tracer.prototype.eventEnd = function (trace, event, data) {
   }
 
   event.endAt = Ntp._now();
-  event.duration = event.endAt - event.at;
 
   if (data) {
     let info = { type: trace.type, name: trace.name };
@@ -259,7 +258,6 @@ Tracer.prototype.buildTrace = function (traceInfo) {
   let metrics = {
     compute: 0,
     async: 0,
-    totalNonCompute: 0,
   };
 
   let firstEvent = traceInfo.events[0];
@@ -281,10 +279,6 @@ Tracer.prototype.buildTrace = function (traceInfo) {
   traceInfo.endAt = lastEvent.endAt || lastEvent.at;
 
   metrics.total = traceInfo.endAt - firstEvent.at;
-  metrics.compute = metrics.total - metrics.totalNonCompute;
-
-  // Remove temporary fields
-  delete metrics.totalNonCompute;
 
   traceInfo.metrics = metrics;
   traceInfo.events = processedEvents;
@@ -311,8 +305,7 @@ Tracer.prototype.optimizeEvent = function (objectEvent, metrics) {
     return objectEvent;
   }
 
-
-  let {at, endAt, stack, nested = [], name, forcedEnd, type, data, level = 0} = objectEvent;
+  let { at, endAt, stack, nested = [], name, forcedEnd, type, data, level = 0 } = objectEvent;
 
   const optimizedNestedEvents = this._hasUsefulNested(objectEvent) ? this.optimizeEvents(nested, metrics) : undefined;
 
@@ -331,9 +324,7 @@ Tracer.prototype.optimizeEvent = function (objectEvent, metrics) {
       extraInfo.forcedEnd = true;
     }
 
-    objectEvent.duration = endAt - at;
-
-    const {duration} = objectEvent;
+    let duration = endAt - at;
 
     // We need this info as events are not always in order or in series.
     extraInfo.at = at;
@@ -343,7 +334,6 @@ Tracer.prototype.optimizeEvent = function (objectEvent, metrics) {
     if (metrics && duration > 0 && level === 0) {
       metrics[type] = metrics[type] || 0;
       metrics[type] += duration;
-      metrics.totalNonCompute += duration;
     }
 
     // Start and end events do not have duration.

--- a/lib/tracer/tracer.js
+++ b/lib/tracer/tracer.js
@@ -287,6 +287,15 @@ Tracer.prototype.buildTrace = function (traceInfo) {
   return traceInfo;
 };
 
+function incrementMetric (metrics, name, value) {
+  if (!metrics || value === 0) {
+    return;
+  }
+
+  metrics[name] = metrics[name] || 0;
+  metrics[name] += value;
+}
+
 /**
  * There are two formats for traces. While the method/publication is running, the trace is in the object format.
  * This is easier to work with, but takes more space to store. After the trace is complete (either finished or errored),
@@ -299,7 +308,7 @@ Tracer.prototype.buildTrace = function (traceInfo) {
  * @param {Object} metrics A metrics object to be updated along the optimization process.
  * @returns {Array} Array notation of the event optimized for transport.
  */
-Tracer.prototype.optimizeEvent = function (objectEvent, metrics) {
+Tracer.prototype.optimizeEvent = function (objectEvent, prevEnded, metrics) {
   if (Array.isArray(objectEvent)) {
     // If it is an array, it is already optimized
     return objectEvent;
@@ -307,7 +316,6 @@ Tracer.prototype.optimizeEvent = function (objectEvent, metrics) {
 
   let { at, endAt, stack, nested = [], name, forcedEnd, type, data, level = 0 } = objectEvent;
 
-  const optimizedNestedEvents = this._hasUsefulNested(objectEvent) ? this.optimizeEvents(nested, metrics) : undefined;
 
   // Unused data is removed at the end
   const optimizedEvent = [type, 0, EMPTY_OBJECT, null];
@@ -318,6 +326,7 @@ Tracer.prototype.optimizeEvent = function (objectEvent, metrics) {
     forcedEnd,
   };
 
+  // Start and end events do not have duration or nested events.
   if (![EventType.Complete, EventType.Start].includes(type)) {
     if (!endAt) {
       // TODO: this might make the metrics a little off since it could be a
@@ -328,19 +337,23 @@ Tracer.prototype.optimizeEvent = function (objectEvent, metrics) {
     }
 
     let duration = endAt - at;
-
-    // We need this info as events are not always in order or in series.
-    extraInfo.at = at;
-    extraInfo.endAt = endAt;
-    extraInfo.nested = optimizedNestedEvents;
+    optimizedEvent[1] = duration;
 
     if (metrics && duration > 0 && level === 0) {
       metrics[type] = metrics[type] || 0;
       metrics[type] += duration;
     }
 
-    // Start and end events do not have duration.
-    optimizedEvent[1] = duration;
+    let offset = prevEnded - at;
+    if (offset < 0) {
+      throw new Error('Monti APM: unexpected gap between events');
+    } else if (offset > 0) {
+      extraInfo.offset = offset;
+    }
+
+    if (this._hasUsefulNested(nested)) {
+      extraInfo.nested = this.optimizeEvent(nested, metrics);
+    }
   }
 
   if (data) {
@@ -374,7 +387,7 @@ Tracer.prototype.optimizeEvents = function (events, metrics) {
 
   let computeTime;
 
-  processedEvents.push(this.optimizeEvent(events[0], metrics));
+  processedEvents.push(this.optimizeEvent(events[0], events[0].at, metrics));
 
   let previousEnd = events[0].at + (processedEvents[0][1] || 0);
 
@@ -385,10 +398,11 @@ Tracer.prototype.optimizeEvents = function (events, metrics) {
 
     if (computeTime > 0) {
       processedEvents.push([EventType.Compute, computeTime]);
-      metrics.compute += computeTime;
+      incrementMetric(metrics, 'compute', computeTime);
+      previousEnd += computeTime;
     }
 
-    let processedEvent = this.optimizeEvent(event, metrics);
+    let processedEvent = this.optimizeEvent(event, previousEnd, metrics);
     processedEvents.push(processedEvent);
 
     previousEnd = event.at + (processedEvent[1] || 0);

--- a/lib/tracer/tracer.js
+++ b/lib/tracer/tracer.js
@@ -320,6 +320,9 @@ Tracer.prototype.optimizeEvent = function (objectEvent, metrics) {
 
   if (![EventType.Complete, EventType.Start].includes(type)) {
     if (!endAt) {
+      // TODO: this might make the metrics a little off since it could be a
+      // couple ms since the trace ended. This should use the same timestamp
+      // as when the trace ended
       endAt = Ntp._now();
       extraInfo.forcedEnd = true;
     }
@@ -363,7 +366,7 @@ Tracer.prototype.optimizeEvent = function (objectEvent, metrics) {
 };
 
 Tracer.prototype.optimizeEvents = function (events, metrics) {
-  if (!events) {
+  if (!events || events.length === 0) {
     return [];
   }
 
@@ -373,17 +376,22 @@ Tracer.prototype.optimizeEvents = function (events, metrics) {
 
   processedEvents.push(this.optimizeEvent(events[0], metrics));
 
+  let previousEnd = events[0].at + (processedEvents[0][1] || 0);
+
   for (let i = 1; i < events.length; i += 1) {
-    let prevEvent = events[i - 1];
     let event = events[i];
 
-    computeTime = event.at - (prevEvent.endAt || prevEvent.at);
+    computeTime = event.at - previousEnd;
 
     if (computeTime > 0) {
       processedEvents.push([EventType.Compute, computeTime]);
+      metrics.compute += computeTime;
     }
 
-    processedEvents.push(this.optimizeEvent(event, metrics));
+    let processedEvent = this.optimizeEvent(event, metrics);
+    processedEvents.push(processedEvent);
+
+    previousEnd = event.at + (processedEvent[1] || 0);
   }
 
   if (processedEvents.length > MAX_TRACE_EVENTS) {

--- a/lib/tracer/tracer.js
+++ b/lib/tracer/tracer.js
@@ -175,10 +175,6 @@ Tracer.prototype.asyncEvent = function (type, data, meta, fn) {
 
   const event = this.event(info.trace, type, data, meta);
 
-  if (event) {
-    event.parentEvent = getActiveEvent();
-  }
-
   let reset = this.setActiveEvent(event);
   let result;
 

--- a/lib/tracer/tracer.js
+++ b/lib/tracer/tracer.js
@@ -246,9 +246,12 @@ Tracer.prototype.endLastEvent = function (traceInfo) {
 // which is not helpful. This returns true if
 // there are nested events other than async.
 Tracer.prototype._hasUsefulNested = function (event) {
-  return event.nested &&
-    event.nested.length &&
-    !event.nested.every(e => e.type === 'async');
+  if (!event.nested || event.nested.length === 0) {
+    return false;
+  }
+
+  return event.type === Event.Custom ||
+    event.nested.some(e => e.type !== 'async');
 };
 
 Tracer.prototype.buildTrace = function (traceInfo) {
@@ -294,26 +297,29 @@ function incrementMetric (metrics, name, value) {
 }
 
 /**
- * There are two formats for traces. While the method/publication is running, the trace is in the object format.
- * This is easier to work with, but takes more space to store. After the trace is complete (either finished or errored),
+ * There are two formats for traces. While the method/publication is running,
+ * the trace is in the object format. This is easier to work with, but takes more
+ * space to store. After the trace is complete (either finished or errored),
  * it is built which among other things converts the events to the array format.
  *
- * The key difference of `optimizeEvent` and `optimizeEvents` is that they do not mutate the original events.
+ * optimizeEvent does not mutate the events, so it can safely be called
+ * multiple times for the same trace
  *
  * @param {Object} objectEvent Expanded object event.
  *
  * @param {Number}  prevEnded The timestamp the previous event ended
- * @param {Object} metrics A metrics object to be updated along the optimization process.
+ * @param {Object} nestedMetrics A metrics object to be updated for nested events
+ *                 Only include if the nested events should affect metrics
  * @returns {Array} Array notation of the event optimized for transport.
  */
-Tracer.prototype.optimizeEvent = function (objectEvent, prevEnded, metrics) {
+Tracer.prototype.optimizeEvent = function (objectEvent, prevEnded, nestedMetrics) {
   if (Array.isArray(objectEvent)) {
     // If it is an array, it is already optimized
     return objectEvent;
   }
 
-  let { at, endAt, stack, nested = [], name, forcedEnd, type, data, level = 0 } = objectEvent;
-
+  let { at, endAt, stack, nested = [], name, forcedEnd, type, data } = objectEvent;
+  let isCustom = type === EventType.Custom;
 
   // Unused data is removed at the end
   const optimizedEvent = [type, 0, EMPTY_OBJECT, null];
@@ -337,11 +343,6 @@ Tracer.prototype.optimizeEvent = function (objectEvent, prevEnded, metrics) {
     let duration = endAt - at;
     optimizedEvent[1] = duration;
 
-    if (metrics && duration > 0 && level === 0) {
-      metrics[type] = metrics[type] || 0;
-      metrics[type] += duration;
-    }
-
     let offset = prevEnded - at;
     if (offset < 0) {
       throw new Error('Monti APM: unexpected gap between events');
@@ -352,11 +353,24 @@ Tracer.prototype.optimizeEvent = function (objectEvent, prevEnded, metrics) {
     if (this._hasUsefulNested(objectEvent)) {
       let nestedStartedAt = nested[0].at;
       let beginningCompute = nestedStartedAt - at;
-      extraInfo.nested = this.optimizeEvents(nested, metrics);
+      extraInfo.nested = this.optimizeEvents(nested, nestedMetrics);
 
       if (beginningCompute > 0) {
         extraInfo.nested.unshift(['compute', beginningCompute]);
+        incrementMetric(nestedMetrics, 'compute', beginningCompute);
       }
+
+      let lastEvent = last(nested);
+      let lastEndedAt = lastEvent.at + (last(extraInfo.nested)[1] || 0);
+      let endComputeTime = endAt - lastEndedAt;
+      if (endComputeTime > 0) {
+        extraInfo.nested.push(['compute', endComputeTime]);
+        incrementMetric(nestedMetrics, 'compute', endComputeTime);
+      }
+    } else if (isCustom) {
+      // If there are no nested events, record everything as compute time
+      extraInfo.nested = [['compute', duration]];
+      incrementMetric(nestedMetrics, 'compute', duration);
     }
   }
 
@@ -398,6 +412,7 @@ Tracer.prototype.optimizeEvents = function (events, metrics) {
 
   for (let i = 1; i < events.length; i += 1) {
     let event = events[i];
+    let isCustomEvent = event.type === EventType.Custom;
 
     computeTime = event.at - previousEnd;
 
@@ -412,7 +427,11 @@ Tracer.prototype.optimizeEvents = function (events, metrics) {
       }
     }
 
-    let processedEvent = this.optimizeEvent(event, previousEnd);
+    let processedEvent = this.optimizeEvent(
+      event,
+      previousEnd,
+      isCustomEvent ? metrics : undefined
+    );
     processedEvents.push(processedEvent);
 
     let duration = processedEvent[1] || 0;
@@ -421,7 +440,11 @@ Tracer.prototype.optimizeEvents = function (events, metrics) {
     if (duration > 0 && previousEnd > countedUntil) {
       let count = previousEnd - countedUntil;
       assert(count <= duration, 'unexpected gap in countedUntil');
-      incrementMetric(metrics, processedEvent[0], count);
+
+      // The nested events are used instead
+      if (!isCustomEvent) {
+        incrementMetric(metrics, processedEvent[0], count);
+      }
 
       countedUntil = previousEnd;
     }

--- a/lib/tracer/tracer.js
+++ b/lib/tracer/tracer.js
@@ -347,8 +347,8 @@ Tracer.prototype.optimizeEvent = function (objectEvent, prevEnded, metrics) {
       extraInfo.offset = offset;
     }
 
-    if (this._hasUsefulNested(nested)) {
-      extraInfo.nested = this.optimizeEvent(nested, metrics);
+    if (this._hasUsefulNested(objectEvent)) {
+      extraInfo.nested = this.optimizeEvents(nested, metrics);
     }
   }
 

--- a/lib/tracer/tracer.js
+++ b/lib/tracer/tracer.js
@@ -4,6 +4,7 @@ import { CreateUserStack, DefaultUniqueId, isPromise, last } from '../utils';
 import { Ntp } from '../ntp';
 import { EventType, MaxAsyncLevel } from '../constants';
 import { getActiveEvent, getInfo, getStore, MontiAsyncStorage } from '../async/als';
+import assert from 'assert';
 
 let eventLogger = require('debug')('kadira:tracer');
 
@@ -301,6 +302,7 @@ function incrementMetric (metrics, name, value) {
  *
  * @param {Object} objectEvent Expanded object event.
  *
+ * @param {Number}  prevEnded The timestamp the previous event ended
  * @param {Object} metrics A metrics object to be updated along the optimization process.
  * @returns {Array} Array notation of the event optimized for transport.
  */
@@ -392,6 +394,7 @@ Tracer.prototype.optimizeEvents = function (events, metrics) {
   processedEvents.push(this.optimizeEvent(events[0], events[0].at, metrics));
 
   let previousEnd = events[0].at + (processedEvents[0][1] || 0);
+  let countedUntil = previousEnd;
 
   for (let i = 1; i < events.length; i += 1) {
     let event = events[i];
@@ -400,14 +403,28 @@ Tracer.prototype.optimizeEvents = function (events, metrics) {
 
     if (computeTime > 0) {
       processedEvents.push([EventType.Compute, computeTime]);
-      incrementMetric(metrics, 'compute', computeTime);
       previousEnd += computeTime;
+
+      if (previousEnd > countedUntil) {
+        let diff = Math.min(computeTime, previousEnd - countedUntil);
+        incrementMetric(metrics, 'compute', diff);
+        countedUntil = previousEnd;
+      }
     }
 
-    let processedEvent = this.optimizeEvent(event, previousEnd, metrics);
+    let processedEvent = this.optimizeEvent(event, previousEnd);
     processedEvents.push(processedEvent);
 
-    previousEnd = event.at + (processedEvent[1] || 0);
+    let duration = processedEvent[1] || 0;
+    previousEnd = event.at + duration;
+
+    if (duration > 0 && previousEnd > countedUntil) {
+      let count = previousEnd - countedUntil;
+      assert(count <= duration, 'unexpected gap in countedUntil');
+      incrementMetric(metrics, processedEvent[0], count);
+
+      countedUntil = previousEnd;
+    }
   }
 
   if (processedEvents.length > MAX_TRACE_EVENTS) {

--- a/lib/tracer/tracer.js
+++ b/lib/tracer/tracer.js
@@ -414,6 +414,17 @@ Tracer.prototype.optimizeEvents = function (events, metrics) {
     let event = events[i];
     let isCustomEvent = event.type === EventType.Custom;
 
+    // There are sometimes extra async events related to the previous event.
+    // Ignore new async events that end before last event.
+    // These events don't contribute anything to the metrics or compute events.
+    if (
+      event.type === EventType.Async &&
+      event.endAt &&
+      event.endAt <= previousEnd
+    ) {
+      continue;
+    }
+
     computeTime = event.at - previousEnd;
 
     if (computeTime > 0) {

--- a/tests/_helpers/helpers.js
+++ b/tests/_helpers/helpers.js
@@ -347,21 +347,21 @@ export function cleanEvents (events) {
   });
 }
 
-export function cleanBuiltEvents (events) {
+export function cleanBuiltEvents (events, roundTo = 10) {
   return events
     .filter(event => event[0] !== 'compute' || event[1] > 5)
     .map(event => {
       let [, duration, , details] = event;
       if (typeof duration === 'number') {
         // round down to nearest 10
-        event[1] = Math.floor(duration / 10) * 10;
+        event[1] = Math.floor(duration / roundTo) * roundTo;
       }
 
       if (details) {
         delete details.at;
         delete details.endAt;
         if (details.nested) {
-          details.nested = cleanBuiltEvents(details.nested);
+          details.nested = cleanBuiltEvents(details.nested, roundTo);
         }
 
         // We only care about the properties that survive being stringified
@@ -369,7 +369,7 @@ export function cleanBuiltEvents (events) {
         event[3] = JSON.parse(JSON.stringify(details));
         if (event[3].offset) {
           // round down to nearest 10
-          event[3].offset = Math.floor(event[3].offset / 10) * 10;
+          event[3].offset = Math.floor(event[3].offset / roundTo) * roundTo;
         }
       }
 

--- a/tests/_helpers/helpers.js
+++ b/tests/_helpers/helpers.js
@@ -121,12 +121,7 @@ export function getLastMethodEvents (indices = [0], keysToPreserve = []) {
   }
 
   function filterFields (event) {
-    let filteredEvent = [];
-
-    indices.forEach((index) => {
-      filteredEvent.push(clean(event[index]));
-    });
-
+    let filteredEvent = indices.map((index) => clean(event[index]));
     cleanTrailingNilValues(filteredEvent);
 
     return filteredEvent;
@@ -372,6 +367,10 @@ export function cleanBuiltEvents (events) {
         // We only care about the properties that survive being stringified
         // (are not undefined)
         event[3] = JSON.parse(JSON.stringify(details));
+        if (event[3].offset) {
+          // round down to nearest 10
+          event[3].offset = Math.floor(event[3].offset / 10) * 10;
+        }
       }
 
       return event;

--- a/tests/_helpers/helpers.js
+++ b/tests/_helpers/helpers.js
@@ -382,6 +382,24 @@ export const dumpEvents = (events) => {
   console.log(JSON.stringify(events));
 };
 
+export function deepFreeze (obj) {
+  if (Array.isArray(obj)) {
+    obj.forEach(val => {
+      if (!Object.isFrozen(val)) {
+        deepFreeze(val);
+      }
+    });
+  } else {
+    Object.values(obj).forEach(val => {
+      if (!Object.isFrozen(val)) {
+        deepFreeze(val);
+      }
+    });
+  }
+
+  Object.freeze(obj);
+}
+
 export const TestHelpers = {
   methodStore: MethodStore,
   getLatestEventsFromMethodStore: () => MethodStore[MethodStore.length - 1].events,

--- a/tests/client/models/errors.js
+++ b/tests/client/models/errors.js
@@ -119,7 +119,7 @@ Tinytest.addAsync(
   function (test, done) {
     let em = new ErrorModel({
       maxErrorsPerInterval: 2,
-      intervalInMillis: 200
+      intervalInMillis: 100
     });
 
     em.sendError({name: 'hoo'});
@@ -130,7 +130,7 @@ Tinytest.addAsync(
       test.equal(em.canSendErrors(), true);
       em.close();
       done();
-    }, 250);
+    }, 200);
   }
 );
 

--- a/tests/hijack/base.js
+++ b/tests/hijack/base.js
@@ -15,8 +15,8 @@ addAsyncTest(
 
     let expected = [
       ['start',{userId: null,params: '[10,"abc"]'}],
-      ['wait',{waitOn: []},{at: 1,endAt: 1}],
-      ['db',{coll: 'tinytest-data',func: 'insertAsync'},{at: 1,endAt: 1}],
+      ['wait',{waitOn: []}],
+      ['db',{coll: 'tinytest-data',func: 'insertAsync'}],
       ['complete']
     ];
 

--- a/tests/hijack/db.js
+++ b/tests/hijack/db.js
@@ -23,7 +23,7 @@ addAsyncTest(
 
     dumpEvents(events);
 
-    let expected = [['start',{userId: null,params: '[]'}],['wait',{waitOn: []},{at: 1,endAt: 1}],['db',{coll: 'tinytest-data',func: 'insertAsync'},{at: 1,endAt: 1}],['complete']];
+    let expected = [['start',{userId: null,params: '[]'}],['wait',{waitOn: []}],['db',{coll: 'tinytest-data',func: 'insertAsync'}],['complete']];
 
     test.stableEqual(events, expected);
   }
@@ -44,7 +44,7 @@ addAsyncTest(
 
     let events = getLastMethodEvents([0, 2, 3]);
 
-    let expected = [['start',{userId: null,params: '[]'}],['wait',{waitOn: []},{at: 1,endAt: 1}],['db',{coll: 'tinytest-data',func: 'insertAsync'},{at: 1,endAt: 1}],['db',{coll: 'tinytest-data',func: 'insertAsync',err: 'E11000'},{at: 1,endAt: 1}],['complete']];
+    let expected = [['start',{userId: null,params: '[]'}],['wait',{waitOn: []}],['db',{coll: 'tinytest-data',func: 'insertAsync'}],['db',{coll: 'tinytest-data',func: 'insertAsync',err: 'E11000'}],['complete']];
 
     test.stableEqual(events, expected);
   }
@@ -64,7 +64,7 @@ addAsyncTest(
 
     let events = getLastMethodEvents([0, 2, 3]);
 
-    let expected = [['start',{userId: null,params: '[]'}],['wait',{waitOn: []},{at: 1,endAt: 1}],['db',{coll: 'tinytest-data',func: 'updateAsync',selector: '{"_id":"aa"}',updatedDocs: 1},{at: 1,endAt: 1}],['complete']];
+    let expected = [['start',{userId: null,params: '[]'}],['wait',{waitOn: []}],['db',{coll: 'tinytest-data',func: 'updateAsync',selector: '{"_id":"aa"}',updatedDocs: 1}],['complete']];
 
     test.stableEqual(events, expected);
   }
@@ -84,7 +84,7 @@ addAsyncTest(
 
     let events = getLastMethodEvents([0, 2, 3]);
 
-    let expected = [['start',{userId: null,params: '[]'}],['wait',{waitOn: []},{at: 1,endAt: 1}],['db',{coll: 'tinytest-data',func: 'removeAsync',selector: '{"_id":"aa"}',removedDocs: 1},{at: 1,endAt: 1}],['complete']];
+    let expected = [['start',{userId: null,params: '[]'}],['wait',{waitOn: []}],['db',{coll: 'tinytest-data',func: 'removeAsync',selector: '{"_id":"aa"}',removedDocs: 1}],['complete']];
 
     test.stableEqual(events, expected);
   }
@@ -103,7 +103,7 @@ addAsyncTest(
 
     let events = getLastMethodEvents([0, 2, 3]);
 
-    let expected = [['start',{userId: null,params: '[]'}],['wait',{waitOn: []},{at: 1,endAt: 1}],['db',{coll: 'tinytest-data',selector: '{"_id":"aa"}',func: 'fetch',cursor: true,limit: 1,docsFetched: 1,docSize: 1},{at: 1,endAt: 1}],['complete']];
+    let expected = [['start',{userId: null,params: '[]'}],['wait',{waitOn: []}],['db',{coll: 'tinytest-data',selector: '{"_id":"aa"}',func: 'fetch',cursor: true,limit: 1,docsFetched: 1,docSize: 1}],['complete']];
 
     test.equal(result, {_id: 'aa', dd: 10});
 
@@ -129,7 +129,7 @@ addAsyncTest(
 
     test.equal(result, {_id: 'aa', dd: 10});
 
-    const expected = [['start',0,{userId: null,params: '[]'}],['wait',0,{waitOn: []},{at: 1,endAt: 1}],['db',0,{coll: 'tinytest-data',selector: '{"_id":"aa"}',func: 'fetch',cursor: true,projection: '{"dd":1}',sort: '{"dd":-1}',limit: 1,docsFetched: 1,docSize: 1},{at: 1,endAt: 1}],['complete']];
+    const expected = [['start',0,{userId: null,params: '[]'}],['wait',0,{waitOn: []}],['db',0,{coll: 'tinytest-data',selector: '{"_id":"aa"}',func: 'fetch',cursor: true,projection: '{"dd":1}',sort: '{"dd":-1}',limit: 1,docsFetched: 1,docSize: 1}],['complete']];
 
     test.stableEqual(events, expected);
   }
@@ -148,7 +148,7 @@ addAsyncTest(
 
     let events = getLastMethodEvents([0, 2, 3]);
 
-    let expected = [['start',{userId: null,params: '[]'}],['wait',{waitOn: []},{at: 1,endAt: 1}],['db',{coll: 'tinytest-data',func: 'upsert',selector: '{"_id":"aa"}',updatedDocs: 1,insertedId: 'aa'},{at: 1,endAt: 1}],['db',{coll: 'tinytest-data',func: 'upsert',selector: '{"_id":"aa"}',updatedDocs: 1},{at: 1,endAt: 1}],['complete']];
+    let expected = [['start',{userId: null,params: '[]'}],['wait',{waitOn: []}],['db',{coll: 'tinytest-data',func: 'upsert',selector: '{"_id":"aa"}',updatedDocs: 1,insertedId: 'aa'}],['db',{coll: 'tinytest-data',func: 'upsert',selector: '{"_id":"aa"}',updatedDocs: 1}],['complete']];
 
     test.stableEqual(events, expected);
   }

--- a/tests/hijack/http.js
+++ b/tests/hijack/http.js
@@ -16,8 +16,8 @@ addAsyncTest('HTTP - meteor/http - call a server', async function (test) {
 
   const expected = [
     ['start',{userId: null,params: '[]'}],
-    ['wait',{waitOn: []},{at: 1,endAt: 1}],
-    ['http',{method: 'GET',url: 'http://localhost:3301',library: 'meteor/http',statusCode: 1,async: true},{at: 1,endAt: 1}],
+    ['wait',{waitOn: []}],
+    ['http',{method: 'GET',url: 'http://localhost:3301',library: 'meteor/http',statusCode: 1,async: true}],
     ['complete']
   ];
 

--- a/tests/hijack/mongo_driver_events.js
+++ b/tests/hijack/mongo_driver_events.js
@@ -2,7 +2,7 @@ import { getMongoDriverStats, resetMongoDriverStats } from '../../lib/hijack/mon
 import { addAsyncTest } from '../_helpers/helpers';
 import { TestData } from '../_helpers/globals';
 
-function checkRange (value, disabledValue, min, max) {
+function checkRange (value, min, max) {
   if (typeof value !== 'number') {
     throw new Error(`${value} is not a number`);
   }
@@ -33,15 +33,15 @@ addAsyncTest(
 
     const stats = getMongoDriverStats();
 
-    checkRange(stats.poolSize, 0, 10, 100);
+    checkRange(stats.poolSize, 10, 100);
     test.equal(stats.primaryCheckouts, 200);
     test.equal(stats.otherCheckouts, 0);
     // TODO: these maximum numbers seem too high
-    checkRange(stats.checkoutTime, 0, 100, 40000);
-    checkRange(stats.maxCheckoutTime, 0, 10, 300);
-    checkRange(stats.pending, 0, 0, 200);
-    checkRange(stats.checkedOut, 0, 0, 15);
-    checkRange(stats.created, 0, 1, 100);
+    checkRange(stats.checkoutTime, 100, 40000);
+    checkRange(stats.maxCheckoutTime, 10, 300);
+    checkRange(stats.pending, 0, 200);
+    checkRange(stats.checkedOut, 0, 20);
+    checkRange(stats.created, 1, 100);
   }
 );
 

--- a/tests/hijack/user.js
+++ b/tests/hijack/user.js
@@ -16,8 +16,8 @@ addAsyncTest(
 
     let expected = [
       ['start',{userId: null,params: '[]'}],
-      ['wait',{waitOn: []},{at: 1,endAt: 1}],
-      ['db',{coll: 'tinytest-data',func: 'insertAsync'},{at: 1,endAt: 1}],
+      ['wait',{waitOn: []}],
+      ['db',{coll: 'tinytest-data',func: 'insertAsync'}],
       ['complete']
     ];
 

--- a/tests/tracer/tracer.js
+++ b/tests/tracer/tracer.js
@@ -291,7 +291,7 @@ addAsyncTest(
       'custom',
       0,
       data,
-      { name: 'test' }
+      { name: 'test', nested: [] }
     ];
     let actualEvent = cleanBuiltEvents(info.trace.events)
       .find(event => event[0] === 'custom');
@@ -392,12 +392,8 @@ addAsyncTest(
         nested: [
           ['compute', 40],
           ['db', 0, { coll: 'tinytest-data', func: 'insertAsync' }],
-          ['async', 0, {}, { offset: 0 }],
-          ['async', 0, {}, { offset: 0 }]
         ]
       }],
-      ['async', 0, {}, { offset: 0 }],
-      ['async', 0, {}, { offset: 0 }],
       ['compute', 0],
       ['complete']
     ];
@@ -416,7 +412,6 @@ addAsyncTest(
       doCompute(20);
       await Kadira.event('test', async () => {
         await TestData.insertAsync({});
-        await TestData.insertAsync({});
         doCompute(41);
       });
       doCompute(20);
@@ -433,16 +428,9 @@ addAsyncTest(
         name: 'test',
         nested: [
           ['db', 0, { coll: 'tinytest-data', func: 'insertAsync' }],
-          ['async', 0, {}, { offset: 0 }],
-          ['async', 0, {}, { offset: 0 }],
-          ['db', 0, { coll: 'tinytest-data', func: 'insertAsync' }],
-          ['async', 0, {}, { offset: 0 }],
-          ['async', 0, {}, { offset: 0 }],
           ['compute', 40],
         ]
       }],
-      ['async', 40, {}, { offset: 40 }],
-      ['async', 40, {}, { offset: 40 }],
       ['compute', 20],
       ['complete']
     ];
@@ -451,10 +439,7 @@ addAsyncTest(
 
     test.stableEqual(actual, expected);
 
-    console.log('metrics -- 2', info.trace.metrics);
-
     test.equal(info.trace.metrics.compute >= 70, true);
-    test.equal(info.trace.metrics.db > 0, true);
     test.equal(info.trace.metrics.async < 5, true);
     test.equal(info.trace.metrics.custom, undefined);
   }
@@ -476,10 +461,10 @@ addAsyncTest(
     });
 
     await callAsync(methodId);
-    console.log('metrics --', info.trace.metrics);
+
     test.equal(info.trace.metrics.compute >= 50, true);
     test.equal(info.trace.metrics.db > 0, true);
-    test.equal(info.trace.metrics.async > 10, true);
+    test.equal(info.trace.metrics.async >= 10, true);
     test.equal(info.trace.metrics.custom, undefined);
   }
 );

--- a/tests/tracer/tracer.js
+++ b/tests/tracer/tracer.js
@@ -999,17 +999,17 @@ addAsyncTest('Tracer - Build Trace - the correct number of async events are capt
   let info;
 
   const methodId = registerMethod(async function () {
-    await sleep(100);
-    await sleep(200);
+    await sleep(60);
+    await sleep(70);
 
     info = getInfo();
 
-    return await sleep(300);
+    return await sleep(80);
   });
 
   await callAsync(methodId);
 
-  const asyncEvents = info.trace.events.filter(([type, duration]) => type === EventType.Async && duration >= 100);
+  const asyncEvents = info.trace.events.filter(([type, duration]) => type === EventType.Async && duration >= 50);
 
   test.equal(asyncEvents.length, 3);
 });

--- a/tests/tracer/tracer.js
+++ b/tests/tracer/tracer.js
@@ -741,7 +741,7 @@ addAsyncTest('Tracer - Build Trace - should end async events', async (test) => {
   let info;
 
   const methodId = registerMethod(async function () {
-    await sleep(20);
+    await sleep(21);
 
     info = getInfo();
   });

--- a/tests/tracer/tracer.js
+++ b/tests/tracer/tracer.js
@@ -445,8 +445,8 @@ addAsyncTest(
 
     const expected = [
       ['start'],
-      ['wait', traceInfo.events[1][1], {}, { at: 0, endAt: traceInfo.events[1][3].endAt, forcedEnd: true }],
-      ['db', 500, {}, { at: 2000, endAt: 2500}],
+      ['wait', traceInfo.events[1][1], {}, { forcedEnd: true }],
+      ['db', 500, {}, { offset: traceInfo.events[2][3].offset }],
       ['complete']
     ];
 
@@ -647,16 +647,14 @@ addAsyncTest('Tracer - Build Trace - custom with nested parallel events', async 
     ['start',{userId: null,params: '[]'}],
     ['wait',{waitOn: []}],
     ['custom', {}, {name: 'test',
-      at: 1,
-      endAt: 1,
       nested: [
         ['db',{coll: 'tinytest-data',func: 'insertAsync'}],
         ['db',{coll: 'tinytest-data',func: 'insertAsync'}],
         ['db',{coll: 'tinytest-data',func: 'insertAsync'}],
-        ['email',{from: 'arunoda@meteorhacks.com',to: 'hello@meteor.com', func: 'emailAsync'}],
+        ['email',{from: 'arunoda@meteorhacks.com',to: 'hello@meteor.com', func: 'emailAsync'}, { offset: 1 }],
         ['db',{coll: 'tinytest-data',selector: '{"_id":"a"}',func: 'fetch',cursor: true,limit: 1,docsFetched: 1,docSize: 1}],
-        ['db',{coll: 'tinytest-data',selector: '{"_id":"b"}',func: 'fetch',cursor: true,limit: 1,docsFetched: 1,docSize: 1}],
-        ['db',{coll: 'tinytest-data',selector: '{"_id":"c"}',func: 'fetch',cursor: true,limit: 1,docsFetched: 1,docSize: 1}],
+        ['db',{coll: 'tinytest-data',selector: '{"_id":"b"}',func: 'fetch',cursor: true,limit: 1,docsFetched: 1,docSize: 1}, { offset: 1 }],
+        ['db',{coll: 'tinytest-data',selector: '{"_id":"c"}',func: 'fetch',cursor: true,limit: 1,docsFetched: 1,docSize: 1}, { offset: 1 }],
         ['db',{coll: 'tinytest-data',selector: '{"_id":"a1"}',func: 'fetch',cursor: true,limit: 1,docsFetched: 0,docSize: 0}],
         ['db',{coll: 'tinytest-data',selector: '{"_id":"a2"}',func: 'fetch',cursor: true,limit: 1,docsFetched: 0,docSize: 0}]
       ]}
@@ -683,7 +681,7 @@ addAsyncTest('Tracer - Build Trace - should end custom event', async (test) => {
 
   const expected = [
     ['start', 0, { userId: null, params: '[]' }],
-    ['wait', 0, { waitOn: []}, {}],
+    ['wait', 0, { waitOn: []}],
     ['custom', 0, { async: false }, {
       name: 'test',
       nested: [
@@ -695,7 +693,7 @@ addAsyncTest('Tracer - Build Trace - should end custom event', async (test) => {
   ];
   let actual = cleanBuiltEvents(info.trace.events);
 
-  test.equal(actual, expected);
+  test.stableEqual(actual, expected);
 });
 
 addAsyncTest('Tracer - Build Trace - should end async events', async (test) => {
@@ -711,13 +709,13 @@ addAsyncTest('Tracer - Build Trace - should end async events', async (test) => {
 
   const expected = [
     ['start', 0, { userId: null, params: '[]' }],
-    ['wait', 0, { waitOn: [] }, {}],
+    ['wait', 0, { waitOn: [] }],
     ['async', 20],
     ['complete']
   ];
   let actual = cleanBuiltEvents(info.trace.events);
 
-  test.equal(actual, expected);
+  test.stableEqual(actual, expected);
 });
 
 addAsyncTest('Tracer - Build Trace - the correct number of async events are captured for methods', async (test) => {

--- a/tests/tracer/tracer.js
+++ b/tests/tracer/tracer.js
@@ -387,10 +387,10 @@ addAsyncTest(
       ['start', 0, { userId: null, params: '[]' }],
       ['wait', 0, { waitOn: [] }],
       ['compute', 20],
-      ['custom', 50, {}, {
+      ['custom', 40, {}, {
         name: 'test',
         nested: [
-          ['compute', 50],
+          ['compute', 40],
           ['db', 0, { coll: 'tinytest-data', func: 'insertAsync' }],
           ['async', 0, {}, { offset: 0 }],
           ['async', 0, {}, { offset: 0 }]
@@ -398,10 +398,10 @@ addAsyncTest(
       }],
       ['async', 0, {}, { offset: 0 }],
       ['async', 0, {}, { offset: 0 }],
-      ['compute', 10],
+      ['compute', 0],
       ['complete']
     ];
-    let actual = cleanBuiltEvents(info.trace.events);
+    let actual = cleanBuiltEvents(info.trace.events, 20);
 
     test.stableEqual(actual, expected);
   }
@@ -962,10 +962,10 @@ addAsyncTest('Tracer - Build Trace - should end custom event', async (test) => {
     ['custom', 0, { async: false }, {
       name: 'test',
       nested: [
-        ['custom', 0, { value: true }, { name: 'test2' }],
+        ['custom', 0, { value: true }, { name: 'test2', nested: []}],
       ]
     }],
-    ['custom', 0, {}, { name: 'test3' }],
+    ['custom', 0, {}, { name: 'test3', nested: [] }],
     ['complete']
   ];
   let actual = cleanBuiltEvents(info.trace.events);


### PR DESCRIPTION
Some situations add extra async events, such as with `Collection.insertAsync`, or when awaiting a custom event. Any async events that end before the previous event are ignored which removes most of these.

The at/endAt timestamps are replaced with an offset value. This reduces the size of the traces, and the timestamps can be calculated using the offsets.

Nested events are always kept for custom events.

Compute events:
- fixes extra compute events when an event is force ended
- track compute at beginning and end of nested events for a custom event
- if there are no nested events for a custom event, a nested compute event is added

Metrics:
- each millisecond is only counted once (if you add each individual metric, it should always equal the total metric).
- for custom events, use the nested events for the metrics instead of the custom event