### PR TITLE
Disable instrumentation when no appId

### DIFF
--- a/lib/hijack/instrument.js
+++ b/lib/hijack/instrument.js
@@ -19,6 +19,10 @@ import { hijackDBOps } from './db';
 
 let instrumented = false;
 Kadira._startInstrumenting = function (callback) {
+  if (!(Meteor.settings?.kadira?.appId || process.env.KADIRA_APP_ID || Meteor.settings?.monti?.appId || process.env.MONTI_APP_ID)) {
+    console.log('Monti instrumentation is disabled.');
+    return;
+  }
   if (instrumented) {
     callback();
     return;


### PR DESCRIPTION
Useful when you want to fully disable instrumentation overhead without remove the package