### PR TITLE
chore: enables console rule as error on lint

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -105,7 +105,7 @@ rules:
   no-catch-shadow: 2
   no-class-assign: 2
   no-cond-assign: 2
-  no-console: 0
+  no-console: 2
   no-const-assign: 2
   no-constant-condition: 2
   no-continue: 0
@@ -277,3 +277,7 @@ rules:
   prefer-rest-params: 0
   symbol-description: 1
   callback-return: 0
+overrides:
+  - files: ['**/tests/**/*.{js,cjs,mjs}']
+    rules:
+      no-console: 0

--- a/lib/common/send.js
+++ b/lib/common/send.js
@@ -23,7 +23,8 @@ Kadira.send = function (payload, path, callback) {
     if (retryCount < 5) {
       retry.retryLater(retryCount++, send);
     } else {
-      console.warn('Error sending error traces to Monti APM server');
+      // eslint-disable-next-line no-console
+      console.warn('Monti APM: Error sending error traces to Monti APM server');
       if (callback) {
         callback(err);
       }

--- a/lib/conflicting_agents.js
+++ b/lib/conflicting_agents.js
@@ -9,6 +9,7 @@ const conflictingPackages = [
 Meteor.startup(() => {
   conflictingPackages.forEach(name => {
     if (name in Package) {
+      // eslint-disable-next-line no-console
       console.log(
         `Monti APM: your app is using the ${name} package. Using more than one APM agent in an app can cause unexpected problems.`
       );

--- a/lib/hijack/error.js
+++ b/lib/hijack/error.js
@@ -54,6 +54,7 @@ export function TrackUncaughtExceptions () {
     // since we are capturing error, we are also on the error message.
     // so developers think we are also reponsible for the error.
     // But we are not. This will fix that.
+    // eslint-disable-next-line no-console
     console.error(err.stack);
     process.exit(7);
   }
@@ -88,7 +89,9 @@ export function TrackUnhandledRejections () {
 
     // We could emit a warning instead like Node does internally
     // but it requires Node 8 or newer
+    // eslint-disable-next-line no-console
     console.warn(message);
+    // eslint-disable-next-line no-console
     console.error(reason && reason.stack ? reason.stack : reason);
   });
 }

--- a/lib/hijack/gc.js
+++ b/lib/hijack/gc.js
@@ -60,6 +60,7 @@ export default class GCMetrics {
       case constants.NODE_PERFORMANCE_GC_WEAKCB:
         return 'gcWeakCB';
       default:
+        // eslint-disable-next-line no-console
         console.log(`Monti APM: Unrecognized GC Kind: ${gcKind}`);
     }
   }

--- a/lib/hijack/timeout_manager.js
+++ b/lib/hijack/timeout_manager.js
@@ -40,6 +40,7 @@ export const TimeoutManager = {
 
       Monti.trackError(error, { type, subType: 'server', kadiraInfo });
 
+      // eslint-disable-next-line no-console
       console.warn(`[Monti APM] ${error.message}`);
     }, timeout);
   },

--- a/lib/kadira.js
+++ b/lib/kadira.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /* global MontiProfiler */
 
 import { Meteor } from 'meteor/meteor';

--- a/lib/models/system.js
+++ b/lib/models/system.js
@@ -51,6 +51,7 @@ export function SystemModel () {
     try {
       await this.getFreeMemory();
     } catch (e) {
+      // eslint-disable-next-line no-console
       console.log('Monti APM: failed to get memory info', e);
     }
   }, 2000);
@@ -123,6 +124,7 @@ SystemModel.prototype.getFreeMemory = async function () {
       return true;
     }
   } catch (e) {
+    // eslint-disable-next-line no-console
     console.error('Monti APM: failed to get native memory info, falling back to default option', e);
   }
 

--- a/lib/ntp.js
+++ b/lib/ntp.js
@@ -164,6 +164,7 @@ function getLogger () {
       arguments[0] = message;
     }
 
+    // eslint-disable-next-line no-console
     console.log(...arguments);
   };
 }

--- a/lib/profiler/client.js
+++ b/lib/profiler/client.js
@@ -5,5 +5,6 @@ Kadira.profileCpu = function profileCpu () {
   const message =
     'Please install montiapm:profiler' +
     ' to take a CPU profile.';
+  // eslint-disable-next-line no-console
   console.log(message);
 };

--- a/lib/sourcemaps.js
+++ b/lib/sourcemaps.js
@@ -63,6 +63,7 @@ export function handleApiResponse (body = {}) {
           handleApiResponse(_body);
         })
         .catch(function (err) {
+          // eslint-disable-next-line no-console
           console.log('Monti APM: unable to send data', err);
         });
     }
@@ -75,6 +76,7 @@ function sendSourcemap (sourcemap, sourcemapPath) {
   let stream = fs.createReadStream(sourcemapPath);
 
   stream.on('error', (err) => {
+    // eslint-disable-next-line no-console
     console.log('Monti APM: error while uploading sourcemap', err);
   });
 
@@ -84,6 +86,7 @@ function sendSourcemap (sourcemap, sourcemapPath) {
 
   Kadira.coreApi.sendStream(`/sourcemap?arch=${arch}&archVersion=${archVersion}&file=${file}`, stream)
     .catch(function (err) {
+      // eslint-disable-next-line no-console
       console.log('Monti APM: error uploading sourcemap', err);
     });
 }

--- a/lib/tracer/tracer.js
+++ b/lib/tracer/tracer.js
@@ -45,6 +45,7 @@ Tracer.prototype.start = function (name, type, {
   }
 
   if (TRACE_TYPES.indexOf(type) === -1) {
+    // eslint-disable-next-line no-console
     console.warn(`Monti APM: unknown trace type "${type}"`);
     return null;
   }
@@ -105,8 +106,11 @@ Tracer.prototype.event = function (traceInfo, type, data, metaData) {
 
   if (lastEvent && !lastEvent.endAt) {
     if (!lastEvent.nested) {
+      // eslint-disable-next-line no-console
       console.error('Monti: invalid trace. Please share the trace below at');
+      // eslint-disable-next-line no-console
       console.error('Monti: https://github.com/monti-apm/monti-apm-agent/issues/14');
+      // eslint-disable-next-line no-console
       console.dir(traceInfo, { depth: 10 });
     }
     let lastNested = lastEvent.nested[lastEvent.nested.length - 1];
@@ -220,10 +224,12 @@ Tracer.prototype.buildTrace = function (traceInfo) {
   let processedEvents = [];
 
   if (firstEvent.type !== 'start') {
+    // eslint-disable-next-line no-console
     console.warn('Monti APM: trace has not started yet');
     return null;
   } else if (lastEvent.type !== 'complete' && lastEvent.type !== 'error') {
     // trace is not completed or errored yet
+    // eslint-disable-next-line no-console
     console.warn('Monti APM: trace has not completed or errored yet');
     return null;
   }
@@ -250,6 +256,7 @@ Tracer.prototype.buildTrace = function (traceInfo) {
     let event = traceInfo.events[lc];
 
     if (!event.endAt) {
+      // eslint-disable-next-line no-console
       console.error('Monti APM: no end event for type: ', event.type);
       return null;
     }

--- a/tools/mock_engine.js
+++ b/tools/mock_engine.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 const http = require('http');
 const app = http.createServer((req, res) => {
   console.log('AUTH:', req.headers);


### PR DESCRIPTION
Enables console rule as error on lint and exclude with ignore line logs that we know are fine and also exclude tests folders from this validation