### PR TITLE
3.0: Fix redis subscriber process not being awaited

### DIFF
--- a/lib/hijack/redis_oplog.js
+++ b/lib/hijack/redis_oplog.js
@@ -143,7 +143,7 @@ export async function wrapRedisOplogObserveDriver (driver) {
     if (op !== 'r' && protectAgainstRaceConditions(collection)) {
       Kadira.models.pubsub.trackPolledDocuments(this.observableCollection._ownerInfo, 1);
     }
-    originalRedisProcess.call(this, op, doc, fields);
+    return originalRedisProcess.call(this, op, doc, fields);
   };
 
   // @todo check this


### PR DESCRIPTION
We spotted an issue on our side when a optimistic method would create a document it would quickly appear in minimongo, dissapear, and appear again.

Upon debugging we found out the the culprit is the `redisSubscriberProto.process` monkey patch.  This method is awaited in redis-oplog source https://github.com/Meteor-Community-Packages/redis-oplog/blob/master/lib/redis/RedisSubscriptionManager.js#L153, and is executed in order for all subscribers.

Applying this change fixes the issue on our side