### PR TITLE
Fix cached document count calculation in hijackObserveMethods #142

### DIFF
--- a/lib/hijack/db/hijack-observe-methods.js
+++ b/lib/hijack/db/hijack-observe-methods.js
@@ -37,7 +37,13 @@ export function hijackObserveMethods () {
             let observerDriverClass = observerDriver.constructor;
             endData.oplog = typeof observerDriverClass.cursorSupported === 'function';
 
-            endData.noOfCachedDocs = ret._multiplexer._cache.docs._map.size;
+            if (ret._multiplexer._cache.ordered) {
+              // ret._multiplexer._cache.docs is OrderedDict
+              endData.noOfCachedDocs = ret._multiplexer._cache.docs._size;
+            } else {
+              // ret._multiplexer._cache.docs is _IdMap
+              endData.noOfCachedDocs = ret._multiplexer._cache.docs._map.size;
+            }
 
             // if multiplexerWasNotReady, we need to get the time spend for the polling
             if (!ret._wasMultiplexerReady) {


### PR DESCRIPTION
When `options.ordered` is set to `true` in `_CachingChangeObserver`, the `this.docs` property will now be initialized as an `OrderedDict` instead of `_IdMap`.

https://github.com/meteor/meteor/blob/2892718148a4453f31223b96e09aa7814ad80fae/packages/minimongo/local_collection.js#L962-L1009

This will fix issue #142.