### PR TITLE
Skip pubsub error tracking for deactivated subscriptions

### DIFF
--- a/lib/models/pubsub.js
+++ b/lib/models/pubsub.js
@@ -107,7 +107,15 @@ PubsubModel.prototype._trackReady = function (session, sub, trace) {
 };
 
 PubsubModel.prototype._trackError = function (session, sub, trace) {
-  logger('ERROR:', session.id, sub._subscriptionId);
+  let sessionId = session && session.id;
+  let subscriptionId = sub && sub._subscriptionId;
+
+  if (!sessionId || !subscriptionId) {
+    logger('ERROR: skipping deactivated subscription');
+    return;
+  }
+
+  logger('ERROR:', sessionId, subscriptionId);
   // use the current time to track the response time
   let publication = this._getPublicationName(sub._name);
   let timestamp = Ntp._now();

--- a/tests/models/pubsub.js
+++ b/tests/models/pubsub.js
@@ -201,6 +201,28 @@ addTestWithRoundedTime(
 );
 
 addTestWithRoundedTime(
+  'Models - PubSub - trackError - deactivated subscription',
+  async function (test) {
+    let model = new PubsubModel();
+    let trace = {
+      type: 'pubsub',
+      name: 'postsList',
+      metrics: {total: 25},
+      events: [],
+    };
+
+    test.equal(
+      model._trackError(null, {_subscriptionId: 'sub-1', _name: 'postsList'}, trace),
+      undefined
+    );
+
+    let payload = model.buildPayload();
+    test.equal(payload.pubMetrics, []);
+    test.equal(payload.pubRequests, []);
+  }
+);
+
+addTestWithRoundedTime(
   'Models - PubSub - Observer Cache - no cache',
   async function (test) {
     let original = Kadira.syncedDate.getTime;


### PR DESCRIPTION
## Summary
- skip pubsub error tracking when the subscription has already been torn down and the session or subscription id is no longer available
- add a regression test covering the deactivated-subscription case so the fix lives in the agent instead of app code

## Why
A Meteor app migration on top of the fiberless branch needed an app-side patch around `Kadira.models.pubsub._trackError` to avoid crashes when a publication error arrives after the subscription has already been deactivated. This moves that guard into the agent itself.

## Validation
- `npm run lint -- --no-cache`
- `mtest --package ./ --once --release 3.0`