### PR TITLE
Guard against null session in _trackSub and _trackUnsub (Meteor 3.4.1+)

### DIFF
--- a/lib/models/pubsub.js
+++ b/lib/models/pubsub.js
@@ -30,7 +30,8 @@ export function PubsubModel () {
 }
 
 PubsubModel.prototype._trackSub = function (session, msg) {
-  logger('SUB:', session.id, msg.id, msg.name, msg.params);
+  // Starting in Meteor 3.4.1, session can be null, if the subscription stopped
+  logger('SUB:', session?.id, msg.id, msg.name, msg.params);
   let publication = this._getPublicationName(msg.name);
   let timestamp = Ntp._now();
   let metrics = this._getMetrics(timestamp, publication);
@@ -47,13 +48,16 @@ PubsubModel.prototype._trackSub = function (session, msg) {
   };
 
   // set session startedTime
-  session._startTime = session._startTime || timestamp;
+  if (session) {
+    session._startTime = session._startTime || timestamp;
+  }
 };
 
 _.extend(PubsubModel.prototype, KadiraModel.prototype);
 
 PubsubModel.prototype._trackUnsub = function (session, sub) {
-  logger('UNSUB:', session.id, sub._subscriptionId);
+  // Starting in Meteor 3.4.1, session can be null, if the subscription stopped
+  logger('UNSUB:', session?.id, sub._subscriptionId);
   let publication = this._getPublicationName(sub._name);
   let subscriptionId = sub._subscriptionId;
   let subscriptionState = this.subscriptions[subscriptionId];
@@ -64,8 +68,9 @@ PubsubModel.prototype._trackUnsub = function (session, sub) {
     startTime = subscriptionState.startTime;
   } else {
     // if this is null subscription, which is started automatically
-    // hence, we don't have a state
-    startTime = session._startTime;
+    // hence, we don't have a state. session can be null in Meteor 3.4.1+
+    // when the subscription has already stopped.
+    startTime = session?._startTime ?? null;
   }
 
   // in case, we can't get the startTime


### PR DESCRIPTION
## Problem

Under Meteor 3.4.1+, `Subscription._session` is set to `null` when a subscription is deactivated (e.g. the client disconnects mid-publish). The pub/sub tracking wrappers run *before* delegating to Meteor's original handlers (which guard via `_isDeactivated()`), so they can receive a null `session`.

`01fc40a` ("Fix tracking error after publication stopped") guarded `_trackReady` and `_trackError`, but **`_trackSub` and `_trackUnsub` were left unguarded** and still dereference `session` unconditionally:

- `_trackSub` — `logger('SUB:', session.id, …)` and `session._startTime = session._startTime || timestamp`
- `_trackUnsub` — `logger('UNSUB:', session.id, …)` and `startTime = session._startTime`

Either throws:

```
TypeError: Cannot read properties of null (reading 'id')
    at PubsubModel._trackSub (packages/montiapm:agent/lib/models/pubsub.js)
```

This is the remaining gap tracked in #150.

## Fix

Mirror the pattern from `01fc40a`:

- Optional-chain the `session?.id` logger argument in both methods.
- Guard the `session._startTime` write in `_trackSub` (`if (session) { … }`).
- Guard the `session._startTime` read in `_trackUnsub` (`session?._startTime ?? null`) — when the session is gone there's no start time, so the existing `if (startTime)` block correctly skips.

Behavior is unchanged for live sessions; deactivated subs are simply no longer tracked (matching how Meteor's own originals no-op when deactivated).

## Tests

The existing null-session tests in `tests/models/pubsub.js` are DDP-integration Tinytests that need the full Meteor harness to run. The `_trackSub`/`_trackUnsub` null-session path is timing-dependent (the session must go null between the wrapper and the original handler), so I've kept this to the source fix consistent with the accepted `01fc40a` change rather than add a flaky repro. Happy to add coverage if you can point me at a deterministic way to null the session in the test harness.

Refs #150.
